### PR TITLE
Abbreviations inside formatters and other commands

### DIFF
--- a/code/abbreviate.py
+++ b/code/abbreviate.py
@@ -1,5 +1,3 @@
-# XXX - would be nice to be able pipe these through formatters
-
 from talon import Context, Module
 
 mod = Module()
@@ -64,6 +62,7 @@ abbreviations = {
     "device": "dev",
     "dictation": "dict",
     "dictionary": "dict",
+    "difference": "diff",
     "direction": "dir",
     "directory": "dir",
     "distribution": "dist",
@@ -78,6 +77,7 @@ abbreviations = {
     "enumerate": "enum",
     "environment": "env",
     "escape": "esc",
+    "estimate": "est",
     "etcetera": "etc",
     "example": "ex",
     "exception": "exc",
@@ -216,3 +216,14 @@ abbreviations = {
 
 ctx = Context()
 ctx.lists["user.abbreviation"] = abbreviations
+
+# In command mode, recognize abbreviations inside formatters and other commands
+#   'all caps snake brief command something' -> CMD_SOMETHING
+#   'funky open brief text' -> def open_txt():
+from .vocabulary import additional_words
+ctx_cmd = Context()
+ctx_cmd.matches = "mode: command"
+ctx_cmd.lists["user.vocabulary"] = {
+    **additional_words,
+    **{"brief " + spoken_form: abbreviation
+       for spoken_form, abbreviation in abbreviations.items()}}

--- a/code/abbreviate.py
+++ b/code/abbreviate.py
@@ -216,14 +216,3 @@ abbreviations = {
 
 ctx = Context()
 ctx.lists["user.abbreviation"] = abbreviations
-
-# In command mode, recognize abbreviations inside formatters and other commands
-#   'all caps snake brief command something' -> CMD_SOMETHING
-#   'funky open brief text' -> def open_txt():
-from .vocabulary import additional_words
-ctx_cmd = Context()
-ctx_cmd.matches = "mode: command"
-ctx_cmd.lists["user.vocabulary"] = {
-    **additional_words,
-    **{"brief " + spoken_form: abbreviation
-       for spoken_form, abbreviation in abbreviations.items()}}

--- a/code/dictation.py
+++ b/code/dictation.py
@@ -12,7 +12,7 @@ setting_context_sensitive_dictation = mod.setting(
     desc="Look at surrounding text to improve auto-capitalization/spacing in dictation mode. By default, this works by selecting that text & copying it to the clipboard, so it may be slow or fail in some applications.",
 )
 
-@mod.capture(rule="({user.vocabulary} | <word>)")
+@mod.capture(rule="({user.vocabulary} | <user.abbreviated> | <word>)")
 def word(m) -> str:
     """A single word, including user-defined vocabulary."""
     try:
@@ -20,18 +20,23 @@ def word(m) -> str:
     except AttributeError:
         return " ".join(actions.dictate.replace_words(actions.dictate.parse_words(m.word)))
 
-@mod.capture(rule="({user.vocabulary} | <phrase>)+")
+@mod.capture(rule="({user.vocabulary} | <user.abbreviated> | <phrase>)+")
 def text(m) -> str:
     """A sequence of words, including user-defined vocabulary."""
     return format_phrase(m)
 
-@mod.capture(rule="({user.vocabulary} | {user.punctuation} | <phrase>)+")
+@mod.capture(rule="({user.vocabulary} | <user.abbreviated> | {user.punctuation} | <phrase>)+")
 def prose(m) -> str:
     """Mixed words and punctuation, auto-spaced & capitalized."""
     text, _state = auto_capitalize(format_phrase(m))
     return text
 
-
+@mod.capture(rule="brief {user.abbreviation}")
+def abbreviated(m) -> str:
+    """A reverse abbreviation inside another command"""
+    return m.abbreviation
+
+
 # ---------- FORMATTING ---------- #
 def format_phrase(m):
     words = capture_to_words(m)

--- a/code/vocabulary.py
+++ b/code/vocabulary.py
@@ -81,11 +81,11 @@ _default_vocabulary.update({word: word for word in _simple_vocab_default})
 # "user.vocabulary" is used to explicitly add words/phrases that Talon doesn't
 # recognize. Words in user.vocabulary (or other lists and captures) are
 # "command-like" and their recognition is prioritized over ordinary words.
-additional_words = get_list_from_csv(
+ctx.lists["user.vocabulary"] = get_list_from_csv(
     "additional_words.csv",
     headers=("Word(s)", "Spoken Form (If Different)"),
-    default=_default_vocabulary)
-ctx.lists["user.vocabulary"] = additional_words
+    default=_default_vocabulary,
+)
 
 # for quick verification of the reload
 # print(str(ctx.settings["dictate.word_map"]))

--- a/code/vocabulary.py
+++ b/code/vocabulary.py
@@ -81,11 +81,11 @@ _default_vocabulary.update({word: word for word in _simple_vocab_default})
 # "user.vocabulary" is used to explicitly add words/phrases that Talon doesn't
 # recognize. Words in user.vocabulary (or other lists and captures) are
 # "command-like" and their recognition is prioritized over ordinary words.
-ctx.lists["user.vocabulary"] = get_list_from_csv(
+additional_words = get_list_from_csv(
     "additional_words.csv",
     headers=("Word(s)", "Spoken Form (If Different)"),
-    default=_default_vocabulary,
-)
+    default=_default_vocabulary)
+ctx.lists["user.vocabulary"] = additional_words
 
 # for quick verification of the reload
 # print(str(ctx.settings["dictate.word_map"]))


### PR DESCRIPTION
This allows reverse abbreviations inside formatters and other commands:
  * _funky read brief text_ → def read_txt():
  * _all caps snake brief command something_ → CMD_SOMETHING
  * _say fancy brief technology comma cool things brief etcetera_ → fancy tech, cool things etc

The implementation is to add several _brief SPOKEN_FORM_  → ABBREVIATION entries to talon's `user.vocabulary` map in a command-mode context. 

Some notes:
  * I'm too new to Talon to know how appropriate / evil messing with `user.vocabulary` is. Maybe there are better solutions? I tried using `dictate.word_map`, but that does not support phrases, as noted in #389.
  * Comments in `code/vocabulary.py` indicate that `user.vocabulary` phrases are given high recognition priority. Since the added phrases all have multiple words starting with 'brief', I imagine this is fine?
  * Surprises can happen if the literal word 'brief' is intended. For example, _snake brief phrase_ → brief_phrase is fine, but _snake brief command_ → cmd, and  _say please make a brief entry_ → please make a ent
  * I left dictation mode alone here, but we could instead update `user.vocabulary` in the global context. That would help dictate things like the third example at the top of the PR.
  * Would it be worth it to also support the long version of the reverse-abbreviate command (_abbreviate X_) inside other commands?
