### PR TITLE
Prefer tmux splits and tabs over containing terminal

### DIFF
--- a/apps/tmux/tmux.py
+++ b/apps/tmux/tmux.py
@@ -1,10 +1,10 @@
 from talon import Context, Module, actions
 
-ctx = Context()
 mod = Module()
 
-ctx.matches = r"""
-tag: user.tmux
+mod.apps.tmux = """
+tag: terminal
+and tag: user.tmux
 """
 
 setting_tmux_prefix_key = mod.setting(
@@ -43,6 +43,10 @@ class TmuxActions:
             f'confirm-before -p "{confirmation_prompt} (y/n)" {command}'
         )
         actions.key("\n")
+
+
+ctx = Context()
+ctx.matches = "app: tmux"
 
 
 @ctx.action_class("app")

--- a/apps/tmux/tmux.talon
+++ b/apps/tmux/tmux.talon
@@ -1,6 +1,17 @@
-tag: user.tmux
+app: tmux
 -
 tag(): user.splits
+tag(): user.tabs
+
+# Note that you will need to add something to match the tmux app in your configuration
+# This is not active by default
+# Adding a file with a matcher for detecting tmux active in your terminal and activating
+# the tmux tag is required
+# Something like:
+#
+# title: /^tmux/
+# -
+# tag(): user.tmux
 
 # pane management - these commands use the word split to match with the splits
 # tag defined in tags/splits/splits.talon


### PR DESCRIPTION
Done by having the context for matching tmux be a more restrictive match than that of the terminals.

This was modeled after the matches for the in-browser Slack and Teams apps.