### PR TITLE
add "copy way {left,right,up,down}"

### DIFF
--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -124,7 +124,7 @@ class Actions:
         actions.edit.copy()
 
     def paste_word():
-        """Paste to word under cursor"""
+        """Paste replacing the word under cursor"""
         actions.edit.select_word()
         actions.edit.paste()
 
@@ -139,7 +139,7 @@ class Actions:
         actions.edit.copy()
 
     def paste_all():
-        """Paste to the current document"""
+        """Paste replacing the current document"""
         actions.edit.select_all()
         actions.edit.paste()
 
@@ -159,7 +159,7 @@ class Actions:
         actions.edit.copy()
 
     def paste_line():
-        """Paste to current line"""
+        """Paste replacing current line"""
         actions.edit.select_line()
         actions.edit.paste()
 
@@ -197,12 +197,12 @@ class Actions:
         actions.edit.copy()
 
     def paste_line_start():
-        """Paste to start of current line"""
+        """Paste replacing until start of current line"""
         actions.user.select_line_start()
         actions.edit.paste()
 
     def paste_line_end():
-        """Paste to end of current line"""
+        """Paste replacing until end of current line"""
         actions.user.select_line_end()
         actions.edit.paste()
 

--- a/core/edit/edit.talon
+++ b/core/edit/edit.talon
@@ -8,11 +8,6 @@ find it: edit.find()
 next one: edit.find_next()
 
 # Navigation
-
-# The reason for these spoken forms is that "page up" and "page down" are globally defined as keys.
-scroll up: edit.page_up()
-scroll down: edit.page_down()
-
 go word left: edit.word_left()
 go word right: edit.word_right()
 
@@ -34,8 +29,11 @@ go way down: edit.file_end()
 go top: edit.file_start()
 go bottom: edit.file_end()
 
+# The reason for these spoken forms is that "page up" and "page down" are globally defined as keys.
 go page up: edit.page_up()
 go page down: edit.page_down()
+scroll up: edit.page_up()
+scroll down: edit.page_down()
 
 # Selecting
 select all: edit.select_all()

--- a/core/edit/edit.talon
+++ b/core/edit/edit.talon
@@ -111,6 +111,19 @@ copy word: user.copy_word()
 copy word left: user.copy_word_left()
 copy word right: user.copy_word_right()
 
+copy way left:
+    edit.extend_line_start()
+    edit.copy()
+copy way right:
+    edit.extend_line_end()
+    edit.copy()
+copy way up:
+    edit.extend_file_start()
+    edit.copy()
+copy way down:
+    edit.extend_file_end()
+    edit.copy()
+
 #to do: do we want these variants, seem to conflict
 # copy left:
 #      edit.extend_left()


### PR DESCRIPTION
Adds "copy way {left,right,up,down}" commands. Also moves the scroll commands in `edit.talon` closer together and clarifies a few doc strings.

See https://github.com/knausj85/knausj_talon/pull/1182