### PR TITLE
typescript: Add type operation commands

### DIFF
--- a/lang/typescript/typescript.talon
+++ b/lang/typescript/typescript.talon
@@ -1,3 +1,10 @@
 tag: user.typescript
 -
 tag(): user.javascript
+
+type union [<user.code_type>]: " | {code_type or ''}"
+type intersect [<user.code_type>]: " & {code_type or ''}"
+
+state type: user.insert_between("type ", " = ")
+
+as const: " as const"


### PR DESCRIPTION
This adds a few commands for some TypeScript type operations:

- `type union/intersect` after a type to union or intersect it with another type
  - example: `type union undefined` will make a type possibly undefined ` | undefined`
- `state type` to start a `type` statement
- `as const` to insert `as const` at the end of an expression