### PR TITLE
don't bail out of get_linux_apps if one desktop file fails

### DIFF
--- a/core/app_switcher/app_switcher.py
+++ b/core/app_switcher/app_switcher.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import talon
 from talon import Context, Module, actions, app, fs, imgui, ui
 
-
 # Construct at startup a list of overides for application names (similar to how homophone list is managed)
 # ie for a given talon recognition word set  `one note`, recognized this in these switcher functions as `ONENOTE`
 # the list is a comma seperated `<Recognized Words>, <Overide>`
@@ -204,7 +203,10 @@ if app.platform == "linux":
                                         args_pattern, "", exec_key
                                     )
                         except:
-                            print("get_linux_apps: skipped parsing application file ", entry.name)
+                            print(
+                                "get_linux_apps: skipped parsing application file ",
+                                entry.name,
+                            )
         return items
 
 

--- a/core/app_switcher/app_switcher.py
+++ b/core/app_switcher/app_switcher.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import talon
 from talon import Context, Module, actions, app, fs, imgui, ui
 
+
 # Construct at startup a list of overides for application names (similar to how homophone list is managed)
 # ie for a given talon recognition word set  `one note`, recognized this in these switcher functions as `ONENOTE`
 # the list is a comma seperated `<Recognized Words>, <Overide>`

--- a/core/app_switcher/app_switcher.py
+++ b/core/app_switcher/app_switcher.py
@@ -185,22 +185,25 @@ if app.platform == "linux":
             if os.path.isdir(base):
                 for entry in os.scandir(base):
                     if entry.name.endswith(".desktop"):
-                        config = configparser.ConfigParser(interpolation=None)
-                        config.read(entry.path)
-                        # only parse shortcuts that are not hidden
-                        if config.has_option("Desktop Entry", "NoDisplay") == False:
-                            name_key = config["Desktop Entry"]["Name"]
-                            exec_key = config["Desktop Entry"]["Exec"]
-                            # remove extra quotes from exec
-                            if exec_key[0] == '"' and exec_key[-1] == '"':
-                                exec_key = re.sub('"', "", exec_key)
-                            # remove field codes and add full path if necessary
-                            if exec_key[0] == "/":
-                                items[name_key] = re.sub(args_pattern, "", exec_key)
-                            else:
-                                items[name_key] = "/usr/bin/" + re.sub(
-                                    args_pattern, "", exec_key
-                                )
+                        try:
+                            config = configparser.ConfigParser(interpolation=None)
+                            config.read(entry.path)
+                            # only parse shortcuts that are not hidden
+                            if config.has_option("Desktop Entry", "NoDisplay") == False:
+                                name_key = config["Desktop Entry"]["Name"]
+                                exec_key = config["Desktop Entry"]["Exec"]
+                                # remove extra quotes from exec
+                                if exec_key[0] == '"' and exec_key[-1] == '"':
+                                    exec_key = re.sub('"', "", exec_key)
+                                # remove field codes and add full path if necessary
+                                if exec_key[0] == "/":
+                                    items[name_key] = re.sub(args_pattern, "", exec_key)
+                                else:
+                                    items[name_key] = "/usr/bin/" + re.sub(
+                                        args_pattern, "", exec_key
+                                    )
+                        except:
+                            print("get_linux_apps: skipped parsing application file ", entry.name)
         return items
 
 


### PR DESCRIPTION
I have experienced this with a desktop file that contains `Terminal=false` twice for some reason