### PR TITLE
`knausj`: rebrand, honor original creator

### DIFF
--- a/BREAKING_CHANGES.txt
+++ b/BREAKING_CHANGES.txt
@@ -1,4 +1,4 @@
-This file lists known changes to knausj_talon that are likely to have broken existing
+This file lists known changes to `community` that are likely to have broken existing
 functionality. The file is sorted by date with the newest entries up the top.
 
 Be aware there may be some difference between the date in this file and when the change was

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-This document attempts to list a set of principles for contributors to the knausj_talon repository to consider. The idea is to document some agreed upon approaches toward reviewing and including code so we can all more easily make consistent decisions.
+This document attempts to list a set of principles for contributors to the `community` repository to consider. The idea is to document some agreed upon approaches toward reviewing and including code so we can all more easily make consistent decisions.
 
 Each of the principles is numbered for easy referencing. The body is formatted as a short single-line summary of the principle followed by elaboration and discussion links.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Each of the principles is numbered for easy referencing. The body is formatted a
 # Voice command principles
 
 - P01 - Prefer [object][verb] rather than [verb][object] for new commands. For example 'file save' is better than 'save file'. It may not sound as natural, but it helps for grouping related commands in lists and avoiding conflicting names.
-- P02 - Use `browser.host` matcher for web apps. Though this matcher requires a [browser extension](https://github.com/knausj85/knausj_talon/blob/main/apps/README.md) on some operating systems it is the only unambiguous way of referring to a web app.
+- P02 - Use `browser.host` matcher for web apps. Though this matcher requires a [browser extension](https://github.com/talonhub/community/blob/main/apps/README.md) on some operating systems it is the only unambiguous way of referring to a web app.
 
 # Coding principles
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@ Voice command set for [Talon](https://talonvoice.com/), community-supported.
 > **Note**
 >
 > Originally called `knausj_talon`, after [its original creator :superhero:](https://github.com/knausj85).
-> You might see the reference to the original name in places.
+>
+> You might see the reference to the original name in places. If you had the old name cloned, you don't have to do anything; GitHub will redirect the old name.
+>
+> However, if you'd like, you can update the remote URL in your existing local repo:
+>
+> `cd ~/.talon/knausj_talon && git remote set-url origin https://github.com/talonhub/community.git`
 
 Can be used on its own, but shines when combined with:
 

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ Note that it is also possible to install knausj by [downloading and extracting a
 1. `help active` will display the available commands for the active application.
    - Available commands can change with the application, or even window title that has focus.
    - You may navigate help using the displayed numbers. e.g., `help one one` or `help eleven` to open the 11th item in the help list.
-   - Note that all help-related commands are defined in [`core/help/help.talon`](https://github.com/talonhub/community.git/blob/main/core/help/help.talon) and [`core/help/help_open.talon`](https://github.com/talonhub/community.git/blob/main/core/help/help_open.talon)
+   - Note that all help-related commands are defined in [`core/help/help.talon`](https://github.com/talonhub/community/blob/main/core/help/help.talon) and [`core/help/help_open.talon`](https://github.com/talonhub/community/blob/main/core/help/help_open.talon)
 2. You can also search for commands by saying `help search <phrase>`. For example, `help search tab` displays all tab-related commands, and `help search help` displays all help-related commands.
 3. You can also jump immediately into a particular help context display by recalling the name displayed in help window (based on the name of the .talon file) e.g. `help symbols` or `help visual studio`
 4. `help alphabet` will display the alphabet
 5. `command history` will toggle a display of the recent commands
 6. `help format` will display the available formatters with examples.
-7. Many useful, basic commands are defined in https://github.com/talonhub/community.git/blob/main/core/edit/standard.talon
+7. Many useful, basic commands are defined in https://github.com/talonhub/community/blob/main/core/edit/standard.talon
    - `undo that` and `redo that` are the default undo/redo commands.
    - `paste that`, `copy that`, and `cut that` for pasting/copy/cutting, respectively.
 8. For community-generated documentation on Talon itself, please visit https://talon.wiki/
@@ -86,7 +86,7 @@ If you use vim, just start with the numbers and alphabet, otherwise look at gene
 ### Alphabet
 
 The alphabet is defined here
-https://github.com/talonhub/community.git/blob/main/core/keys/keys.py#L3
+https://github.com/talonhub/community/blob/main/core/keys/keys.py#L3
 
 `help alphabet` will open a window that displays the alphabet. `help close` to hide the window.
 
@@ -94,9 +94,9 @@ Try saying e.g. `air bat cap` to insert abc.
 
 ### Keys
 
-Keys are defined in keys.py. The alphabet is used for A-Z. For the rest, search for `modifier_keys` and then keep scrolling through the file, eg. roughly https://github.com/talonhub/community.git/blob/main/core/keys/keys.py#L111
+Keys are defined in keys.py. The alphabet is used for A-Z. For the rest, search for `modifier_keys` and then keep scrolling through the file, eg. roughly https://github.com/talonhub/community/blob/main/core/keys/keys.py#L111
 
-All key commands are defined in [keys.talon](https://github.com/talonhub/community.git/blob/main/core/keys/keys.talon). For example, say `shift air` to press `shift-a`, which types a capital `A`.
+All key commands are defined in [keys.talon](https://github.com/talonhub/community/blob/main/core/keys/keys.talon). For example, say `shift air` to press `shift-a`, which types a capital `A`.
 
 On Windows, try commands such as
 
@@ -115,9 +115,9 @@ Any combination of the modifiers, symbols, alphabet, numbers and function keys c
 ### Symbols
 
 Some symbols are defined in keys.py, so you can say e.g. `control colon` to press those keys.
-https://github.com/talonhub/community.git/blob/main/core/keys/keys.py#L140
+https://github.com/talonhub/community/blob/main/core/keys/keys.py#L140
 
-Some other symbols are defined here: https://github.com/talonhub/community.git/blob/main/plugin/symbols/symbols.talon
+Some other symbols are defined here: https://github.com/talonhub/community/blob/main/plugin/symbols/symbols.talon
 
 ### Formatters
 
@@ -128,24 +128,24 @@ Try using formatters by saying e.g. `snake hello world`, which will insert hello
 Multiple formatters can be used together, e.g. `dubstring snake hello world`. This will insert "hello_world"
 
 Formatters (snake, dubstring) are defined here
-https://github.com/talonhub/community.git/blob/main/core/text/formatters.py#L137
+https://github.com/talonhub/community/blob/main/core/text/formatters.py#L137
 
 All formatter-related commands are defined here
-https://github.com/talonhub/community.git/blob/main/core/text/text.talon#L8
+https://github.com/talonhub/community/blob/main/core/text/text.talon#L8
 
 ### Mouse commands
 
-See https://github.com/talonhub/community.git/blob/main/plugin/mouse/mouse.talon
+See https://github.com/talonhub/community/blob/main/plugin/mouse/mouse.talon
 
 ### Generic editing commands
 
-https://github.com/talonhub/community.git/blob/main/core/edit/edit.talon
+https://github.com/talonhub/community/blob/main/core/edit/edit.talon
 
 These generic commands are global. Commands such as `go word left` will work in any text box.
 
 ### Repeating commands
 
-For repeating commands, useful voice commands are defined here: https://github.com/talonhub/community.git/blob/main/plugin/repeater/repeater.talon
+For repeating commands, useful voice commands are defined here: https://github.com/talonhub/community/blob/main/plugin/repeater/repeater.talon
 
 Try saying e.g. `go up fifth` will go up five lines.
 Try saying e.g. `select up third` to hit `shift-up` three times to select some lines in a text field.
@@ -153,7 +153,7 @@ Try saying e.g. `select up third` to hit `shift-up` three times to select some l
 ### Window management
 
 Global window managment commands are defined here:
-https://github.com/talonhub/community.git/blob/main/core/windows_and_tabs/window_management.talon
+https://github.com/talonhub/community/blob/main/core/windows_and_tabs/window_management.talon
 
 - `running list` will toggle a GUI list of words you can say to switch to running applications.
 - `focus chrome` will focus the chrome application.
@@ -161,7 +161,7 @@ https://github.com/talonhub/community.git/blob/main/core/windows_and_tabs/window
 
 ### Screenshot commands
 
-https://github.com/talonhub/community.git/blob/main/plugin/screenshot/screenshot.talon
+https://github.com/talonhub/community/blob/main/plugin/screenshot/screenshot.talon
 
 ### Programming Languages
 
@@ -169,14 +169,14 @@ Specific programming languages may be activated by voice commands, or via title 
 
 Activating languages via commands will enable the commands globally, e.g. they'll work in any application. This will also disable the title tracking method (code.language in .talon files) until the "clear language modes" voice command is used.
 
-The commands for enabling languages are defined here: https://github.com/talonhub/community.git/blob/main/core/modes/language_modes.talon
+The commands for enabling languages are defined here: https://github.com/talonhub/community/blob/main/core/modes/language_modes.talon
 
 By default, title tracking activates coding languages in supported applications such as VSCode, Visual Studio (requires plugin), and Notepad++.
 
 To enable title tracking for your application:
 
 1. The active filename (including extension) must be included in the editor's title
-2. Implement the required Talon-defined `filename` action to correctly extract the filename from the programs's title. See https://github.com/talonhub/community.git/blob/main/apps/vscode/vscode.py#L122-L138 for an example.
+2. Implement the required Talon-defined `filename` action to correctly extract the filename from the programs's title. See https://github.com/talonhub/community/blob/main/apps/vscode/vscode.py#L122-L138 for an example.
 
 Python, C#, Talon and javascript language support is currently broken up into several tags in an attempt to define a common grammar where possible between languages. Each tag is defined by a .talon file, which defines the voice commands, and a Python file which declares the actions that should be implemented by each concrete language implementation to support those voice commands. Currently, the tags which are available are:
 
@@ -202,7 +202,7 @@ The support for the language-specific implementations of actions are then locate
 
 - `lang/{your-language}/{your-language}.py`
 
-To start support for a new language, ensure the appropriate extension is added to the [`language_extensions` in language_modes.py](https://github.com/talonhub/community.git/blob/main/core/modes/language_modes.py#L9).
+To start support for a new language, ensure the appropriate extension is added to the [`language_extensions` in language_modes.py](https://github.com/talonhub/community/blob/main/core/modes/language_modes.py#L9).
 Then create the following files:
 
 - `lang/{your-language}/{your-language}.py`
@@ -214,7 +214,7 @@ You may also want to add a force command to `language_modes.talon`.
 
 ## File Manager commands
 
-For the following file manager commands to work, your file manager must display the full folder path in the title bar. https://github.com/talonhub/community.git/blob/main/tags/file_manager/file_manager.talon
+For the following file manager commands to work, your file manager must display the full folder path in the title bar. https://github.com/talonhub/community/blob/main/tags/file_manager/file_manager.talon
 
 For Mac OS X's Finder, run this command in terminal to display the full path in the title.
 
@@ -236,7 +236,7 @@ Notes:
 To implement support for a new program, you need to implement the relevant file manager actions for your application and assert the user.file_manager tag.
 
 - There are a number of example implementations in the repository. Finder is a good example to copy and customize to your application as needed.
-  https://github.com/talonhub/community.git/blob/main/apps/finder/finder.py
+  https://github.com/talonhub/community/blob/main/apps/finder/finder.py
 
 ## Terminal commands
 
@@ -276,7 +276,7 @@ into each editor.
 
 Several options are configurable via a single settings file out of the box. Any setting can be made context specific as needed (e.g., per-OS, per-app, etc).
 
-https://github.com/talonhub/community.git/blob/main/settings.talon
+https://github.com/talonhub/community/blob/main/settings.talon
 
 ```
 #adjust the scale of the imgui to my liking

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It is recommended to install `community` using [`git`](https://git-scm.com/).
    git clone https://github.com/talonhub/community community
    ```
 
-Note that it is also possible to install knausj by [downloading and extracting a zip file](#alternate-installation-method-zip-file), but this approach is discouraged because it makes it more difficult to keep track of any changes you may make to your copy of the files.
+Note that it is also possible to install `community` by [downloading and extracting a zip file](#alternate-installation-method-zip-file), but this approach is discouraged because it makes it more difficult to keep track of any changes you may make to your copy of the files.
 
 ### Windows
 
@@ -47,7 +47,7 @@ It is recommended to install `community` using [`git`](https://git-scm.com/).
    git clone https://github.com/talonhub/community community
    ```
 
-Note that it is also possible to install knausj by [downloading and extracting a zip file](#alternate-installation-method-zip-file), but this approach is discouraged because it makes it more difficult to keep track of any changes you may make to your copy of the files.
+Note that it is also possible to install `community` by [downloading and extracting a zip file](#alternate-installation-method-zip-file), but this approach is discouraged because it makes it more difficult to keep track of any changes you may make to your copy of the files.
 
 ## Getting started with Talon
 
@@ -303,7 +303,7 @@ Also, you can add additional vocabulary words, words to replace, search engines 
 
 ## Other talon user file sets
 
-In addition to this repo, there are [other Talon user file sets](https://talon.wiki/talon_user_file_sets/) containing additional commands that you may want to experiment with if you're feeling adventurous 😊. Many of them are meant to be used alongside knausj, but a few of them are designed as replacements. If it's not clear which, please file an issue against the given GitHub repository for that user file set!
+In addition to this repo, there are [other Talon user file sets](https://talon.wiki/talon_user_file_sets/) containing additional commands that you may want to experiment with if you're feeling adventurous 😊. Many of them are meant to be used alongside `community`, but a few of them are designed as replacements. If it's not clear which, please file an issue against the given GitHub repository for that user file set!
 
 # Collaborators
 
@@ -341,7 +341,7 @@ You then have a few options as to when to run it:
 - Run yourself at any time on your locally changed files: `pre-commit run`
 - Run yourself on all files in the repository: `pre-commit run --all-files`
 - Run automatically on your PRs (fixes will be pushed automatically to your branch):
-  - Visit https://pre-commit.ci/ and authorize the app to connect to your knausj fork.
+  - Visit https://pre-commit.ci/ and authorize the app to connect to your `community` fork.
 - Set up an editor hook to run on save:
   - You could follow the instructions for [Black](https://black.readthedocs.io/en/stable/integrations/editors.html), which are well written; simply replace `black <path>` with `pre-commit run --files <file>`.
   - It's more performant to only reformat the specific file you're editing, rather than all changed files.
@@ -366,7 +366,7 @@ For community-generated documentation on Talon, please visit https://talon.wiki/
 
 ## Alternate installation method: Zip file
 
-It is possible to install knausj by downloading and extracting a zip file instead of using `git`. Note that this approach is discouraged, because it makes it more difficult to keep track of any changes you may make to your copy of the files.
+It is possible to install `community` by downloading and extracting a zip file instead of using `git`. Note that this approach is discouraged, because it makes it more difficult to keep track of any changes you may make to your copy of the files.
 
 If you wish to install `community` by downloading and extracting a zip file, proceed as follows:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# knausj_talon
+# community
 
-Community-maintained [Talon](https://talonvoice.com/) command grammar.
+Community-maintained [Talon](https://talonvoice.com/) command grammar. _(Note: originally called `knausj_talon`, after [its creator](https://github.com/knausj85))_
 
 Can be used on its own, but shines when combined with:
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,7 @@ Voice command set for [Talon](https://talonvoice.com/), community-supported.
 > **Note**
 >
 > Originally called `knausj_talon`, after [its original creator :superhero:](https://github.com/knausj85).
->
-> You might see the reference to the original name in places. If you had the old name cloned, you don't have to do anything; GitHub will redirect the old name.
->
-> However, if you'd like, you can update the remote URL in your existing local repo:
->
-> `cd ~/.talon/knausj_talon && git remote set-url origin https://github.com/talonhub/community`
+
 
 Can be used on its own, but shines when combined with:
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # community
 
-Voice command set for [Talon](https://talonvoice.com/), community-supported.
-
-> **Note**
->
-> Originally called `knausj_talon`, after [its original creator :superhero:](https://github.com/knausj85).
+Voice command set for [Talon](https://talonvoice.com/), community-supported. _(Note: Originally called `knausj_talon`, after [its original creator :superhero:](https://github.com/knausj85))_
 
 Can be used on its own, but shines when combined with:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Voice command set for [Talon](https://talonvoice.com/), community-supported.
 >
 > Originally called `knausj_talon`, after [its original creator :superhero:](https://github.com/knausj85).
 
-
 Can be used on its own, but shines when combined with:
 
 - [Cursorless](https://www.cursorless.org/) for programming and text editing

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # community
 
-Community-maintained [Talon](https://talonvoice.com/) command grammar.
+Voice command set for [Talon](https://talonvoice.com/), community-supported.
 
 _(Note: originally called `knausj_talon`, after [its creator](https://github.com/knausj85). You might see the reference to the original name in places.)_
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # community
 
-Community-maintained [Talon](https://talonvoice.com/) command grammar. _(Note: originally called `knausj_talon`, after [its creator](https://github.com/knausj85))_
+Community-maintained [Talon](https://talonvoice.com/) command grammar.
+
+_(Note: originally called `knausj_talon`, after [its creator](https://github.com/knausj85). You might see the reference to the original name in places.)_
 
 Can be used on its own, but shines when combined with:
 
@@ -21,7 +23,7 @@ Can be used on its own, but shines when combined with:
 
 ### Linux & Mac
 
-It is recommended to install `knausj_talon` using [`git`](https://git-scm.com/).
+It is recommended to install `community` using [`git`](https://git-scm.com/).
 
 1. Install [`git`](https://git-scm.com/)
 2. Open a terminal ([Mac](https://support.apple.com/en-gb/guide/terminal/apd5265185d-f365-44cb-8b09-71a064a42125/mac) / [Ubuntu](https://ubuntu.com/tutorials/command-line-for-beginners#3-opening-a-terminal))
@@ -29,14 +31,14 @@ It is recommended to install `knausj_talon` using [`git`](https://git-scm.com/).
 
    ```bash
    cd ~/.talon/user
-   git clone https://github.com/knausj85/knausj_talon knausj_talon
+   git clone https://github.com/talonhub/community.git community
    ```
 
 Note that it is also possible to install knausj by [downloading and extracting a zip file](#alternate-installation-method-zip-file), but this approach is discouraged because it makes it more difficult to keep track of any changes you may make to your copy of the files.
 
 ### Windows
 
-It is recommended to install `knausj_talon` using [`git`](https://git-scm.com/).
+It is recommended to install `community` using [`git`](https://git-scm.com/).
 
 1. Install [`git`](https://git-scm.com/)
 2. Open a [terminal](https://www.wikihow.com/Open-the-Command-Prompt-in-Windows)
@@ -44,7 +46,7 @@ It is recommended to install `knausj_talon` using [`git`](https://git-scm.com/).
 
    ```
    cd %AppData%\Talon\user
-   git clone https://github.com/knausj85/knausj_talon knausj_talon
+   git clone https://github.com/talonhub/community.git community
    ```
 
 Note that it is also possible to install knausj by [downloading and extracting a zip file](#alternate-installation-method-zip-file), but this approach is discouraged because it makes it more difficult to keep track of any changes you may make to your copy of the files.
@@ -54,13 +56,13 @@ Note that it is also possible to install knausj by [downloading and extracting a
 1. `help active` will display the available commands for the active application.
    - Available commands can change with the application, or even window title that has focus.
    - You may navigate help using the displayed numbers. e.g., `help one one` or `help eleven` to open the 11th item in the help list.
-   - Note that all help-related commands are defined in [`core/help/help.talon`](https://github.com/knausj85/knausj_talon/blob/main/core/help/help.talon) and [`core/help/help_open.talon`](https://github.com/knausj85/knausj_talon/blob/main/core/help/help_open.talon)
+   - Note that all help-related commands are defined in [`core/help/help.talon`](https://github.com/talonhub/community.git/blob/main/core/help/help.talon) and [`core/help/help_open.talon`](https://github.com/talonhub/community.git/blob/main/core/help/help_open.talon)
 2. You can also search for commands by saying `help search <phrase>`. For example, `help search tab` displays all tab-related commands, and `help search help` displays all help-related commands.
 3. You can also jump immediately into a particular help context display by recalling the name displayed in help window (based on the name of the .talon file) e.g. `help symbols` or `help visual studio`
 4. `help alphabet` will display the alphabet
 5. `command history` will toggle a display of the recent commands
 6. `help format` will display the available formatters with examples.
-7. Many useful, basic commands are defined in https://github.com/knausj85/knausj_talon/blob/main/core/edit/standard.talon
+7. Many useful, basic commands are defined in https://github.com/talonhub/community.git/blob/main/core/edit/standard.talon
    - `undo that` and `redo that` are the default undo/redo commands.
    - `paste that`, `copy that`, and `cut that` for pasting/copy/cutting, respectively.
 8. For community-generated documentation on Talon itself, please visit https://talon.wiki/
@@ -76,7 +78,7 @@ If you use vim, just start with the numbers and alphabet, otherwise look at gene
 ### Alphabet
 
 The alphabet is defined here
-https://github.com/knausj85/knausj_talon/blob/main/core/keys/keys.py#L3
+https://github.com/talonhub/community.git/blob/main/core/keys/keys.py#L3
 
 `help alphabet` will open a window that displays the alphabet. `help close` to hide the window.
 
@@ -84,9 +86,9 @@ Try saying e.g. `air bat cap` to insert abc.
 
 ### Keys
 
-Keys are defined in keys.py. The alphabet is used for A-Z. For the rest, search for `modifier_keys` and then keep scrolling through the file, eg. roughly https://github.com/knausj85/knausj_talon/blob/main/core/keys/keys.py#L111
+Keys are defined in keys.py. The alphabet is used for A-Z. For the rest, search for `modifier_keys` and then keep scrolling through the file, eg. roughly https://github.com/talonhub/community.git/blob/main/core/keys/keys.py#L111
 
-All key commands are defined in [keys.talon](https://github.com/knausj85/knausj_talon/blob/main/core/keys/keys.talon). For example, say `shift air` to press `shift-a`, which types a capital `A`.
+All key commands are defined in [keys.talon](https://github.com/talonhub/community.git/blob/main/core/keys/keys.talon). For example, say `shift air` to press `shift-a`, which types a capital `A`.
 
 On Windows, try commands such as
 
@@ -105,9 +107,9 @@ Any combination of the modifiers, symbols, alphabet, numbers and function keys c
 ### Symbols
 
 Some symbols are defined in keys.py, so you can say e.g. `control colon` to press those keys.
-https://github.com/knausj85/knausj_talon/blob/main/core/keys/keys.py#L140
+https://github.com/talonhub/community.git/blob/main/core/keys/keys.py#L140
 
-Some other symbols are defined here: https://github.com/knausj85/knausj_talon/blob/main/plugin/symbols/symbols.talon
+Some other symbols are defined here: https://github.com/talonhub/community.git/blob/main/plugin/symbols/symbols.talon
 
 ### Formatters
 
@@ -118,24 +120,24 @@ Try using formatters by saying e.g. `snake hello world`, which will insert hello
 Multiple formatters can be used together, e.g. `dubstring snake hello world`. This will insert "hello_world"
 
 Formatters (snake, dubstring) are defined here
-https://github.com/knausj85/knausj_talon/blob/main/core/text/formatters.py#L137
+https://github.com/talonhub/community.git/blob/main/core/text/formatters.py#L137
 
 All formatter-related commands are defined here
-https://github.com/knausj85/knausj_talon/blob/main/core/text/text.talon#L8
+https://github.com/talonhub/community.git/blob/main/core/text/text.talon#L8
 
 ### Mouse commands
 
-See https://github.com/knausj85/knausj_talon/blob/main/plugin/mouse/mouse.talon
+See https://github.com/talonhub/community.git/blob/main/plugin/mouse/mouse.talon
 
 ### Generic editing commands
 
-https://github.com/knausj85/knausj_talon/blob/main/core/edit/edit.talon
+https://github.com/talonhub/community.git/blob/main/core/edit/edit.talon
 
 These generic commands are global. Commands such as `go word left` will work in any text box.
 
 ### Repeating commands
 
-For repeating commands, useful voice commands are defined here: https://github.com/knausj85/knausj_talon/blob/main/plugin/repeater/repeater.talon
+For repeating commands, useful voice commands are defined here: https://github.com/talonhub/community.git/blob/main/plugin/repeater/repeater.talon
 
 Try saying e.g. `go up fifth` will go up five lines.
 Try saying e.g. `select up third` to hit `shift-up` three times to select some lines in a text field.
@@ -143,7 +145,7 @@ Try saying e.g. `select up third` to hit `shift-up` three times to select some l
 ### Window management
 
 Global window managment commands are defined here:
-https://github.com/knausj85/knausj_talon/blob/main/core/windows_and_tabs/window_management.talon
+https://github.com/talonhub/community.git/blob/main/core/windows_and_tabs/window_management.talon
 
 - `running list` will toggle a GUI list of words you can say to switch to running applications.
 - `focus chrome` will focus the chrome application.
@@ -151,7 +153,7 @@ https://github.com/knausj85/knausj_talon/blob/main/core/windows_and_tabs/window_
 
 ### Screenshot commands
 
-https://github.com/knausj85/knausj_talon/blob/main/plugin/screenshot/screenshot.talon
+https://github.com/talonhub/community.git/blob/main/plugin/screenshot/screenshot.talon
 
 ### Programming Languages
 
@@ -159,14 +161,14 @@ Specific programming languages may be activated by voice commands, or via title 
 
 Activating languages via commands will enable the commands globally, e.g. they'll work in any application. This will also disable the title tracking method (code.language in .talon files) until the "clear language modes" voice command is used.
 
-The commands for enabling languages are defined here: https://github.com/knausj85/knausj_talon/blob/main/core/modes/language_modes.talon
+The commands for enabling languages are defined here: https://github.com/talonhub/community.git/blob/main/core/modes/language_modes.talon
 
 By default, title tracking activates coding languages in supported applications such as VSCode, Visual Studio (requires plugin), and Notepad++.
 
 To enable title tracking for your application:
 
 1. The active filename (including extension) must be included in the editor's title
-2. Implement the required Talon-defined `filename` action to correctly extract the filename from the programs's title. See https://github.com/knausj85/knausj_talon/blob/main/apps/vscode/vscode.py#L122-L138 for an example.
+2. Implement the required Talon-defined `filename` action to correctly extract the filename from the programs's title. See https://github.com/talonhub/community.git/blob/main/apps/vscode/vscode.py#L122-L138 for an example.
 
 Python, C#, Talon and javascript language support is currently broken up into several tags in an attempt to define a common grammar where possible between languages. Each tag is defined by a .talon file, which defines the voice commands, and a Python file which declares the actions that should be implemented by each concrete language implementation to support those voice commands. Currently, the tags which are available are:
 
@@ -192,7 +194,7 @@ The support for the language-specific implementations of actions are then locate
 
 - `lang/{your-language}/{your-language}.py`
 
-To start support for a new language, ensure the appropriate extension is added to the [`language_extensions` in language_modes.py](https://github.com/knausj85/knausj_talon/blob/main/core/modes/language_modes.py#L9).
+To start support for a new language, ensure the appropriate extension is added to the [`language_extensions` in language_modes.py](https://github.com/talonhub/community.git/blob/main/core/modes/language_modes.py#L9).
 Then create the following files:
 
 - `lang/{your-language}/{your-language}.py`
@@ -204,7 +206,7 @@ You may also want to add a force command to `language_modes.talon`.
 
 ## File Manager commands
 
-For the following file manager commands to work, your file manager must display the full folder path in the title bar. https://github.com/knausj85/knausj_talon/blob/main/tags/file_manager/file_manager.talon
+For the following file manager commands to work, your file manager must display the full folder path in the title bar. https://github.com/talonhub/community.git/blob/main/tags/file_manager/file_manager.talon
 
 For Mac OS X's Finder, run this command in terminal to display the full path in the title.
 
@@ -226,7 +228,7 @@ Notes:
 To implement support for a new program, you need to implement the relevant file manager actions for your application and assert the user.file_manager tag.
 
 - There are a number of example implementations in the repository. Finder is a good example to copy and customize to your application as needed.
-  https://github.com/knausj85/knausj_talon/blob/main/apps/finder/finder.py
+  https://github.com/talonhub/community.git/blob/main/apps/finder/finder.py
 
 ## Terminal commands
 
@@ -255,7 +257,7 @@ line in [unix_shell.py](tags/terminal/unix_shell.py):
 
 Once you have uncommented the line, you can customize your utility commands by editing
 `settings/unix_utilities.csv`. Note: this directory is created when first running Talon
-with knausj_talon enabled.
+with community enabled.
 
 ## Jetbrains commands
 
@@ -266,7 +268,7 @@ into each editor.
 
 Several options are configurable via a single settings file out of the box. Any setting can be made context specific as needed (e.g., per-OS, per-app, etc).
 
-https://github.com/knausj85/knausj_talon/blob/main/settings.talon
+https://github.com/talonhub/community.git/blob/main/settings.talon
 
 ```
 #adjust the scale of the imgui to my liking
@@ -299,7 +301,7 @@ The most commonly adjusted settings are probably
 
 • `user.mouse_wheel_down_amount` and `user.mouse_continuous_scroll_amount` for adjusting the scroll amounts for the various scroll commands.
 
-Also, you can add additional vocabulary words, words to replace, search engines and more. Complete the knausj_talon setup instructions above, then open the `settings` folder to see the provided CSV files and customize them as needed.
+Also, you can add additional vocabulary words, words to replace, search engines and more. Complete the community setup instructions above, then open the `settings` folder to see the provided CSV files and customize them as needed.
 
 ## Other talon user file sets
 
@@ -368,8 +370,8 @@ For community-generated documentation on Talon, please visit https://talon.wiki/
 
 It is possible to install knausj by downloading and extracting a zip file instead of using `git`. Note that this approach is discouraged, because it makes it more difficult to keep track of any changes you may make to your copy of the files.
 
-If you wish to install `knausj_talon` by downloading and extracting a zip file, proceed as follows:
+If you wish to install `community` by downloading and extracting a zip file, proceed as follows:
 
-1. Download the [zip archive of knausj_talon](https://github.com/knausj85/knausj_talon/archive/refs/heads/main.zip)
+1. Download the [zip archive of community](https://github.com/talonhub/community.git/archive/refs/heads/main.zip)
 1. Extract the files. If you don’t know how to extract zip files, a quick google search for "extract zip files" may be helpful.
 1. Place these extracted files inside the `user` folder of the Talon Home directory. You can find this folder by right clicking the Talon icon in taskbar, clicking Scripting > Open ~/talon, and navigating to `user`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 Voice command set for [Talon](https://talonvoice.com/), community-supported.
 
-_(Note: originally called `knausj_talon`, after [its creator](https://github.com/knausj85). You might see the reference to the original name in places.)_
+> **Note**
+>
+> Originally called `knausj_talon`, after [its original creator :superhero:](https://github.com/knausj85).
+> You might see the reference to the original name in places.
 
 Can be used on its own, but shines when combined with:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Voice command set for [Talon](https://talonvoice.com/), community-supported.
 >
 > However, if you'd like, you can update the remote URL in your existing local repo:
 >
-> `cd ~/.talon/knausj_talon && git remote set-url origin https://github.com/talonhub/community.git`
+> `cd ~/.talon/knausj_talon && git remote set-url origin https://github.com/talonhub/community`
 
 Can be used on its own, but shines when combined with:
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ It is recommended to install `community` using [`git`](https://git-scm.com/).
 
    ```bash
    cd ~/.talon/user
-   git clone https://github.com/talonhub/community.git community
+   git clone https://github.com/talonhub/community community
    ```
 
 Note that it is also possible to install knausj by [downloading and extracting a zip file](#alternate-installation-method-zip-file), but this approach is discouraged because it makes it more difficult to keep track of any changes you may make to your copy of the files.
@@ -54,7 +54,7 @@ It is recommended to install `community` using [`git`](https://git-scm.com/).
 
    ```
    cd %AppData%\Talon\user
-   git clone https://github.com/talonhub/community.git community
+   git clone https://github.com/talonhub/community community
    ```
 
 Note that it is also possible to install knausj by [downloading and extracting a zip file](#alternate-installation-method-zip-file), but this approach is discouraged because it makes it more difficult to keep track of any changes you may make to your copy of the files.
@@ -380,6 +380,6 @@ It is possible to install knausj by downloading and extracting a zip file instea
 
 If you wish to install `community` by downloading and extracting a zip file, proceed as follows:
 
-1. Download the [zip archive of community](https://github.com/talonhub/community.git/archive/refs/heads/main.zip)
+1. Download the [zip archive of community](https://github.com/talonhub/community/archive/refs/heads/main.zip)
 1. Extract the files. If you don’t know how to extract zip files, a quick google search for "extract zip files" may be helpful.
 1. Place these extracted files inside the `user` folder of the Talon Home directory. You can find this folder by right clicking the Talon icon in taskbar, clicking Scripting > Open ~/talon, and navigating to `user`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # community
 
-Voice command set for [Talon](https://talonvoice.com/), community-supported. _(Note: Originally called `knausj_talon`, after [its original creator :superhero:](https://github.com/knausj85))_
+Voice command set for [Talon](https://talonvoice.com/), community-supported.
+
+_(Originally called `knausj_talon`, after [its original creator :superhero:](https://github.com/knausj85))_
 
 Can be used on its own, but shines when combined with:
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,6 +1,8 @@
 # Web apps and browser extensions
 
-Some of the Talon files for web apps (e.g. `apps/github/github_web.talon`) use a `browser.host` matcher. These talon files should work out of the box for Safari, Chrome, Brave, on Mac, but require additional configuration on other browsers/operating systems. `knausj_talon` is set up so that if a URL is found in the titlebar of an application matching the 'browser' tag it will be used to populate the browser.host matcher (see `code/browser.py`). This probably means that you will need an extension to make the browser.host based scripts work.
+Some of the Talon files for web apps (e.g. `apps/github/github_web.talon`) use a `browser.host` matcher. These talon files should work out of the box for Safari, Chrome, Brave, on Mac, but require additional configuration on other browsers/operating systems.
+
+`community` is set up so that if a URL is found in the titlebar of an application matching the 'browser' tag it will be used to populate the browser.host matcher (see `code/browser.py`). This probably means that you will need an extension to make the browser.host based scripts work.
 
 Browser extensions that can add the protocol and hostname or even the entire URL to the window title:
 

--- a/apps/talon_repl/talon_repl.talon
+++ b/apps/talon_repl/talon_repl.talon
@@ -6,7 +6,7 @@ tag(): user.talon_python
 # uncomment user.talon_populate_lists tag to activate talon-specific lists of actions, scopes, modes etcetera.
 # Do not enable this tag with dragon, as it will be unusable.
 # with conformer, the latency increase may also be unacceptable depending on your cpu
-# see https://github.com/knausj85/knausj_talon/issues/600
+# see https://github.com/talonhub/community/issues/600
 # tag(): user.talon_populate_lists
 
 ^test last$:

--- a/apps/vscode/command_client/README.md
+++ b/apps/vscode/command_client/README.md
@@ -4,7 +4,7 @@ This directory contains the client code for communicating with the [VSCode comma
 
 ## Contributing
 
-The source of truth is in https://github.com/knausj85/knausj_talon/tree/main/apps/vscode/command_client, but the code is also maintained as a subtree at https://github.com/pokey/talon-vscode-command-client.
+The source of truth is in https://github.com/talonhub/community/tree/main/apps/vscode/command_client, but the code is also maintained as a subtree at https://github.com/pokey/talon-vscode-command-client.
 
 To contribute, first open a PR on knausj. Once the PR is merged, you can push the changes to the subtree by running the following commands on an up-to-date knausj main: (need write access)
 

--- a/apps/vscode/command_client/README.md
+++ b/apps/vscode/command_client/README.md
@@ -6,7 +6,9 @@ This directory contains the client code for communicating with the [VSCode comma
 
 The source of truth is in https://github.com/talonhub/community/tree/main/apps/vscode/command_client, but the code is also maintained as a subtree at https://github.com/pokey/talon-vscode-command-client.
 
-To contribute, first open a PR on knausj. Once the PR is merged, you can push the changes to the subtree by running the following commands on an up-to-date knausj main: (need write access)
+To contribute, first open a PR on `community`.
+
+Once the PR is merged, you can push the changes to the subtree by running the following commands on an up-to-date `community` main: (need write access)
 
 ```sh
 git subtree split --prefix=apps/vscode/command_client --annotate="[split] " -b split

--- a/core/app_switcher/app_switcher.py
+++ b/core/app_switcher/app_switcher.py
@@ -10,7 +10,7 @@ from talon import Context, Module, actions, app, fs, imgui, ui
 # Construct at startup a list of overides for application names (similar to how homophone list is managed)
 # ie for a given talon recognition word set  `one note`, recognized this in these switcher functions as `ONENOTE`
 # the list is a comma seperated `<Recognized Words>, <Overide>`
-# TODO: Consider put list csv's (homophones.csv, app_name_overrides.csv) files together in a seperate directory,`knausj_talon/lists`
+# TODO: Consider put list csv's (homophones.csv, app_name_overrides.csv) files together in a seperate directory,`community/lists`
 overrides_directory = os.path.dirname(os.path.realpath(__file__))
 override_file_name = f"app_name_overrides.{talon.app.platform}.csv"
 override_file_path = os.path.join(overrides_directory, override_file_name)

--- a/core/deprecations.py
+++ b/core/deprecations.py
@@ -46,7 +46,7 @@ Usages:
         actions.user.deprecate_capture("2023-09-03", "user.legacy_capture")
         # implement capture
 
-See https://github.com/knausj85/knausj_talon/issues/940 for original discussion
+See https://github.com/talonhub/community/issues/940 for original discussion
 """
 
 import datetime

--- a/core/deprecations.py
+++ b/core/deprecations.py
@@ -3,7 +3,7 @@ Helpers for deprecating voice commands, actions, and captures. Since Talon can
 be an important part of people's workflows providing a warning before removing
 functionality is encouraged.
 
-The normal deprecation process in knausj_talon is as follows:
+The normal deprecation process in `community` is as follows:
 
 1. For 6 months from deprecation a deprecated action or command should
    continue working. Put an entry in the BREAKING_CHANGES.txt file in the

--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -35,7 +35,7 @@ class EditActions:
         actions.edit.paste()
 
     # # This simpler implementation of select_word mostly works, but in some apps it doesn't.
-    # # See https://github.com/knausj85/knausj_talon/issues/1084.
+    # # See https://github.com/talonhub/community/issues/1084.
     # def select_word():
     #     actions.edit.right()
     #     actions.edit.word_left()

--- a/core/edit_text_file.py
+++ b/core/edit_text_file.py
@@ -3,7 +3,7 @@ import subprocess
 
 from talon import Context, Module, app
 
-# path to knausj root directory
+# path to community/knausj root directory
 REPO_DIR = os.path.dirname(os.path.dirname(__file__))
 SETTINGS_DIR = os.path.join(REPO_DIR, "settings")
 

--- a/core/user_settings.py
+++ b/core/user_settings.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from talon import resource
 
 # NOTE: This method requires this module to be one folder below the top-level
-#   knausj folder.
+#   community/knausj folder.
 SETTINGS_DIR = Path(__file__).parents[1] / "settings"
 
 if not SETTINGS_DIR.is_dir():

--- a/lang/talon/talon.py
+++ b/lang/talon/talon.py
@@ -10,7 +10,7 @@ ctx_talon_lists = Context()
 # is active to prevent them from being active in contexts where they are not wanted.
 # Do not enable this tag with dragon, as it will be unusable.
 # with conformer, the latency increase may also be unacceptable depending on your cpu
-# see https://github.com/knausj85/knausj_talon/issues/600
+# see https://github.com/talonhub/community/issues/600
 ctx_talon_lists.matches = r"""
 tag: user.talon_populate_lists
 """

--- a/lang/talon/talon.talon
+++ b/lang/talon/talon.talon
@@ -7,7 +7,7 @@ tag(): user.code_functions_common
 # uncomment user.talon_populate_lists tag to activate talon-specific lists of actions, scopes, modes etcetera.
 # Do not enable this tag with dragon, as it will be unusable.
 # with conformer, the latency increase may also be unacceptable depending on your cpu
-# see https://github.com/knausj85/knausj_talon/issues/600
+# see https://github.com/talonhub/community/issues/600
 # tag(): user.talon_populate_lists
 
 dot talon: insert(".talon")

--- a/plugin/talon_draft_window/README.md
+++ b/plugin/talon_draft_window/README.md
@@ -11,7 +11,7 @@ An session might go like this for example:
     replace gust with error   # Replaces the word corresponding with the red anchor 'g' (gust in community) with the word 'error'
     period                    # Add a full stop
     select each through fine  # Select the words starting at the 'e' anchor and ending at 'f'
-    say without               # Insert the word 'without' (knausj_talon)
+    say without               # Insert the word 'without' (community)
     title word air            # Make the word corresponding to the 'a' anchor capitalised
     draft submit              # Type the text in your draft window back into your editor
     # End with the text "This is a sentence without error." in your editor or other textbox

--- a/plugin/talon_draft_window/README.md
+++ b/plugin/talon_draft_window/README.md
@@ -8,7 +8,7 @@ An session might go like this for example:
 
     # Start with the text "this is a sentence with an elephant." in your editor or other textbox
     draft edit all            # Select all the text in your editor and moves it to the draft window
-    replace gust with error   # Replaces the word corresponding with the red anchor 'g' (gust in knausj_talon) with the word 'error'
+    replace gust with error   # Replaces the word corresponding with the red anchor 'g' (gust in community) with the word 'error'
     period                    # Add a full stop
     select each through fine  # Select the words starting at the 'e' anchor and ending at 'f'
     say without               # Insert the word 'without' (knausj_talon)

--- a/plugin/talon_draft_window/draft_talon_helpers.py
+++ b/plugin/talon_draft_window/draft_talon_helpers.py
@@ -72,7 +72,7 @@ settings.register("", _update_draft_style)
 class ContextSensitiveDictationActions:
     """
     Override these actions to assist 'Smart dictation mode'.
-    see https://github.com/knausj85/knausj_talon/pull/356
+    see https://github.com/talonhub/community/pull/356
     """
 
     def dictation_peek(left, right):

--- a/plugin/talon_draft_window/draft_window.talon
+++ b/plugin/talon_draft_window/draft_window.talon
@@ -2,7 +2,7 @@
 title: Talon Draft
 -
 settings():
-    # Enable 'Smart dictation mode', see https://github.com/knausj85/knausj_talon/pull/356
+    # Enable 'Smart dictation mode', see https://github.com/talonhub/community/pull/356
     user.context_sensitive_dictation = 1
 
 # Replace a single word with a phrase

--- a/plugin/talon_helpers/talon_helpers.talon
+++ b/plugin/talon_helpers/talon_helpers.talon
@@ -51,4 +51,4 @@ talon dump context:
     clip.set_text(result)
 
 talon (bug report | report bug):
-    user.open_url("https://github.com/knausj85/knausj_talon/issues")
+    user.open_url("https://github.com/talonhub/community/issues")

--- a/test/stubs/talon/grammar.py
+++ b/test/stubs/talon/grammar.py
@@ -1,4 +1,4 @@
-# This is a class in the Talon runtime, but is only used as a type in knausj. We
+# This is a class in the Talon runtime, but is only used as a type in `community`. We
 # stub it here as a blank class, since there are (for example) functions which
 # check isinstance(some_input, Phrase), and for testing we want these tests to
 # return False.


### PR DESCRIPTION
https://github.com/talonhub/community/issues/935. We're not in ~Kansas~ knausj anymore...

This updates:

- The main title of the README (as well as most references therein) and adds a note about our origins. [View here]( https://github.com/talonhub/community/tree/rebrand)
    - The cloning instructions in the README.
        - (This might be up for debate; do we want people to `git clone https://github.com/talonhub/community community`? Some users might end up with two copies. I think @lunixbochs had a plan to check for if people have both knausj and community cloned duplicative side by side by mistake.)
        - GitHub's web UI recommends `https://github.com/talonhub/community.git` as the HTTPS URL, but our old instructions did not include the `.git` suffix. What do we want to do?
- All GitHub links in the form of `https://github.com/knausj85/knausj_talon/`, such as to issues.
- A few manual references in text files, such as in the deprecation process.