### PR TITLE
fix: Handle spaces for 'launch <appname>' in OSX

### DIFF
--- a/core/app_switcher/app_switcher.py
+++ b/core/app_switcher/app_switcher.py
@@ -327,12 +327,15 @@ class Actions:
 
     def switcher_launch(path: str):
         """Launch a new application by path (all OSes), or AppUserModel_ID path on Windows"""
-        if app.platform != "windows":
-            # separate command and arguments
+        if app.platform == "mac":
+            ui.launch(path=path)
+        elif app.platform == "linux":
+            # Could potentially be merged with OSX code. Done in this explicit
+            # way for expediency around the 0.4 release.
             cmd = shlex.split(path)[0]
             args = shlex.split(path)[1:]
             ui.launch(path=cmd, args=args)
-        else:
+        elif app.platform == "windows":
             is_valid_path = False
             try:
                 current_path = Path(path)
@@ -344,6 +347,8 @@ class Actions:
             else:
                 cmd = f"explorer.exe shell:AppsFolder\\{path}"
                 subprocess.Popen(cmd, shell=False)
+        else:
+            print("Unhandled platform in switcher_launch: " + app.platform)
 
     def switcher_menu():
         """Open a menu of running apps to switch to"""
@@ -384,7 +389,7 @@ def update_launch_list():
                 for name in os.listdir(base):
                     path = os.path.join(base, name)
                     name = name.rsplit(".", 1)[0].lower()
-                    launch[name] = f"'{path}'"
+                    launch[name] = path
 
     elif app.platform == "windows":
         launch = get_windows_apps()

--- a/core/app_switcher/app_switcher.py
+++ b/core/app_switcher/app_switcher.py
@@ -384,7 +384,7 @@ def update_launch_list():
                 for name in os.listdir(base):
                     path = os.path.join(base, name)
                     name = name.rsplit(".", 1)[0].lower()
-                    launch[name] = path
+                    launch[name] = f"'{path}'"
 
     elif app.platform == "windows":
         launch = get_windows_apps()


### PR DESCRIPTION
Regression from https://github.com/talonhub/community/pull/1197 . Issue is the code will populate the self.launch list with something like:
```
{
  'my app': '/Applications/My App.app'
}
```
Then later in `actions.user.switcher_launch` `shlex.split` would turn that into `cmd = '/Applications/My', args='App.app'`. Quoting the path makes it treat the whole path as one unit.