### PR TITLE
Added voice command to create Talon application context

### DIFF
--- a/core/app_switcher/app_switcher.py
+++ b/core/app_switcher/app_switcher.py
@@ -327,12 +327,15 @@ class Actions:
 
     def switcher_launch(path: str):
         """Launch a new application by path (all OSes), or AppUserModel_ID path on Windows"""
-        if app.platform != "windows":
-            # separate command and arguments
+        if app.platform == "mac":
+            ui.launch(path=path)
+        elif app.platform == "linux":
+            # Could potentially be merged with OSX code. Done in this explicit
+            # way for expediency around the 0.4 release.
             cmd = shlex.split(path)[0]
             args = shlex.split(path)[1:]
             ui.launch(path=cmd, args=args)
-        else:
+        elif app.platform == "windows":
             is_valid_path = False
             try:
                 current_path = Path(path)
@@ -344,6 +347,8 @@ class Actions:
             else:
                 cmd = f"explorer.exe shell:AppsFolder\\{path}"
                 subprocess.Popen(cmd, shell=False)
+        else:
+            print("Unhandled platform in switcher_launch: " + app.platform)
 
     def switcher_menu():
         """Open a menu of running apps to switch to"""

--- a/plugin/talon_helpers/create_app_context.py
+++ b/plugin/talon_helpers/create_app_context.py
@@ -18,7 +18,7 @@ class Actions:
         app_name = get_app_name(active_app.name)
         app_dir = APPS_DIR / app_name
         filename = get_filename(app_name)
-        talon_file = app_dir / f"{filename}.talon"
+        talon_file = app_dir / f"{app_name}.talon"
         python_file = app_dir / f"{filename}.py"
 
         talon_context = get_talon_context(app_name)

--- a/plugin/talon_helpers/create_app_context.py
+++ b/plugin/talon_helpers/create_app_context.py
@@ -26,8 +26,11 @@ class Actions:
         if not app_dir.is_dir():
             os.mkdir(app_dir)
 
-        create_file(talon_file, talon_context)
-        create_file(python_file, python_context)
+        talon_file_created = create_file(talon_file, talon_context)
+        python_file_created = create_file(python_file, python_context)
+
+        if talon_file_created or python_file_created:
+            actions.user.file_manager_open_directory(str(app_dir))
 
 
 def get_python_context(active_app: ui.App, app_name: str) -> str:
@@ -43,6 +46,7 @@ and {app_context}
 """
 
 ctx.matches = r"""
+os: {os}
 app: {app_name}
 """
 
@@ -63,8 +67,9 @@ def get_talon_context(app_name: str) -> str:
 
 
 def get_platform_filename(app_name: str) -> str:
-    platform = app.platform if app.platform != "windows" else "win"
-    return f"{app_name}_{platform}"
+    if app.platform == "mac":
+        return f"{app_name}_{app.platform}"
+    return app_name
 
 
 def get_app_context(active_app: ui.App) -> str:
@@ -82,10 +87,12 @@ def get_app_name(text: str, max_len=20) -> str:
     ).lower()
 
 
-def create_file(path: Path, content: str):
+def create_file(path: Path, content: str) -> bool:
     if path.is_file():
-        print(f"Application context file '{path}' already exists")
-        return
+        actions.app.notify(f"Application context file '{path}' already exists")
+        return False
 
     with open(path, "w", encoding="utf-8") as file:
         file.write(content)
+
+    return True

--- a/plugin/talon_helpers/create_app_context.py
+++ b/plugin/talon_helpers/create_app_context.py
@@ -12,13 +12,13 @@ mod = Module()
 
 @mod.action_class
 class Actions:
-    def talon_create_app_context():
+    def talon_create_app_context(platform_suffix: str = None):
         """Create a new python context file for the current application"""
         active_app = ui.active_app()
         app_name = get_app_name(active_app.name)
         app_dir = APPS_DIR / app_name
         talon_file = app_dir / f"{app_name}.talon"
-        python_file = app_dir / f"{get_platform_filename(app_name)}.py"
+        python_file = app_dir / f"{get_platform_filename(app_name, platform_suffix)}.py"
 
         talon_context = get_talon_context(app_name)
         python_context = get_python_context(active_app, app_name)
@@ -66,9 +66,9 @@ def get_talon_context(app_name: str) -> str:
 """
 
 
-def get_platform_filename(app_name: str) -> str:
-    if app.platform == "mac":
-        return f"{app_name}_{app.platform}"
+def get_platform_filename(app_name: str, platform_suffix: str = None) -> str:
+    if platform_suffix:
+        return f"{app_name}_{platform_suffix}"
     return app_name
 
 

--- a/plugin/talon_helpers/create_app_context.py
+++ b/plugin/talon_helpers/create_app_context.py
@@ -17,9 +17,8 @@ class Actions:
         active_app = ui.active_app()
         app_name = get_app_name(active_app.name)
         app_dir = APPS_DIR / app_name
-        filename = get_filename(app_name)
         talon_file = app_dir / f"{app_name}.talon"
-        python_file = app_dir / f"{filename}.py"
+        python_file = app_dir / f"{get_platform_filename(app_name)}.py"
 
         talon_context = get_talon_context(app_name)
         python_context = get_python_context(active_app, app_name)
@@ -63,7 +62,7 @@ def get_talon_context(app_name: str) -> str:
 """
 
 
-def get_filename(app_name: str) -> str:
+def get_platform_filename(app_name: str) -> str:
     platform = app.platform if app.platform != "windows" else "win"
     return f"{app_name}_{platform}"
 

--- a/plugin/talon_helpers/create_app_context.py
+++ b/plugin/talon_helpers/create_app_context.py
@@ -17,22 +17,18 @@ class Actions:
         active_app = ui.active_app()
         app_name = create_name(active_app.name)
         app_dir = APPS_DIR / app_name
-        talon_file = app_dir / f"{app_name}.talon"
-        python_file = app_dir / f"{app_name}.py"
-
-        if app_dir.is_dir():
-            raise OSError(f"Application directory '{app_name}' already exists")
+        filename = get_filename(app_name)
+        talon_file = app_dir / f"{filename}.talon"
+        python_file = app_dir / f"{filename}.py"
 
         talon_context = get_talon_context(app_name)
         python_context = get_python_context(active_app, app_name)
 
-        os.mkdir(app_dir)
+        if not app_dir.is_dir():
+            os.mkdir(app_dir)
 
-        with open(talon_file, "w", encoding="utf-8") as file:
-            file.write(talon_context)
-
-        with open(python_file, "w", encoding="utf-8") as file:
-            file.write(python_context)
+        create_file(talon_file, talon_context)
+        create_file(python_file, python_context)
 
 
 def get_python_context(active_app: ui.App, app_name: str) -> str:
@@ -67,6 +63,11 @@ def get_talon_context(app_name: str) -> str:
 """
 
 
+def get_filename(app_name: str) -> str:
+    platform = app.platform if app.platform != "windows" else "win"
+    return f"{app_name}_{platform}"
+
+
 def get_app_context(active_app: ui.App) -> str:
     if app.platform == "mac":
         return f"app.bundle: {active_app.bundle}"
@@ -80,3 +81,12 @@ def create_name(text: str, max_len=20) -> str:
     return "_".join(
         list(islice(pattern.findall(text.replace(".exe", "")), max_len))
     ).lower()
+
+
+def create_file(path: Path, content: str):
+    if path.is_file():
+        print(f"Application context file '{path}' already exists")
+        return 
+
+    with open(path, "w", encoding="utf-8") as file:
+        file.write(content)

--- a/plugin/talon_helpers/create_app_context.py
+++ b/plugin/talon_helpers/create_app_context.py
@@ -13,7 +13,7 @@ mod = Module()
 @mod.action_class
 class Actions:
     def talon_create_app_context(platform_suffix: str = None):
-        """Create a new python context file for the current application"""
+        """Create a new directory with talon and python context files for the current application"""
         active_app = ui.active_app()
         app_name = get_app_name(active_app.name)
         app_dir = APPS_DIR / app_name

--- a/plugin/talon_helpers/create_app_context.py
+++ b/plugin/talon_helpers/create_app_context.py
@@ -15,7 +15,7 @@ class Actions:
     def talon_create_app_context():
         """Create a new python context file for the current application"""
         active_app = ui.active_app()
-        app_name = create_name(active_app.name)
+        app_name = get_app_name(active_app.name)
         app_dir = APPS_DIR / app_name
         filename = get_filename(app_name)
         talon_file = app_dir / f"{filename}.talon"
@@ -76,7 +76,7 @@ def get_app_context(active_app: ui.App) -> str:
     return f"app.name: {active_app.name}"
 
 
-def create_name(text: str, max_len=20) -> str:
+def get_app_name(text: str, max_len=20) -> str:
     pattern = re.compile(r"[A-Z][a-z]*|[a-z]+|\d")
     return "_".join(
         list(islice(pattern.findall(text.replace(".exe", "")), max_len))

--- a/plugin/talon_helpers/create_app_context.py
+++ b/plugin/talon_helpers/create_app_context.py
@@ -1,7 +1,9 @@
-from talon import Module, app, actions, ui
-from pathlib import Path
+import os
+import re
 from itertools import islice
-import os, re
+from pathlib import Path
+
+from talon import Module, actions, app, ui
 
 APPS_DIR = Path(__file__).parent.parent.parent / "apps"
 
@@ -59,13 +61,10 @@ app: {app_name}
 
 
 def get_talon_context(app_name: str) -> str:
-    return """\
-app: {app_name}
+    return f"""app: {app_name}
 -
 
-""".format(
-        app_name=app_name,
-    )
+"""
 
 
 def get_app_context(active_app: ui.App) -> str:

--- a/plugin/talon_helpers/create_app_context.py
+++ b/plugin/talon_helpers/create_app_context.py
@@ -1,0 +1,83 @@
+from talon import Module, app, actions, ui
+from pathlib import Path
+from itertools import islice
+import os, re
+
+APPS_DIR = Path(__file__).parent.parent.parent / "apps"
+
+mod = Module()
+
+
+@mod.action_class
+class Actions:
+    def talon_create_app_context():
+        """Create a new python context file for the current application"""
+        active_app = ui.active_app()
+        app_name = create_name(active_app.name)
+        app_dir = APPS_DIR / app_name
+        talon_file = app_dir / f"{app_name}.talon"
+        python_file = app_dir / f"{app_name}.py"
+
+        if app_dir.is_dir():
+            raise OSError(f"Application directory '{app_name}' already exists")
+
+        talon_context = get_talon_context(app_name)
+        python_context = get_python_context(active_app, app_name)
+
+        os.mkdir(app_dir)
+
+        with open(talon_file, "w", encoding="utf-8") as file:
+            file.write(talon_context)
+
+        with open(python_file, "w", encoding="utf-8") as file:
+            file.write(python_context)
+
+
+def get_python_context(active_app: ui.App, app_name: str) -> str:
+    return '''\
+from talon import Module, Context, actions
+
+mod = Module()
+ctx = Context()
+
+mod.apps.{app_name} = r"""
+os: {os}
+and {app_context}
+"""
+
+ctx.matches = r"""
+app: {app_name}
+"""
+
+# @mod.action_class
+# class Actions:
+'''.format(
+        app_name=app_name,
+        os=app.platform,
+        app_context=get_app_context(active_app),
+    )
+
+
+def get_talon_context(app_name: str) -> str:
+    return """\
+app: {app_name}
+-
+
+""".format(
+        app_name=app_name,
+    )
+
+
+def get_app_context(active_app: ui.App) -> str:
+    if app.platform == "mac":
+        return f"app.bundle: {active_app.bundle}"
+    if app.platform == "windows":
+        return f"app.exe: {active_app.exe.split(os.path.sep)[-1]}"
+    return f"app.name: {active_app.name}"
+
+
+def create_name(text: str, max_len=20) -> str:
+    pattern = re.compile(r"[A-Z][a-z]*|[a-z]+|\d")
+    return "_".join(
+        list(islice(pattern.findall(text.replace(".exe", "")), max_len))
+    ).lower()

--- a/plugin/talon_helpers/talon_helpers.talon
+++ b/plugin/talon_helpers/talon_helpers.talon
@@ -49,6 +49,7 @@ talon dump context:
 ^talon copy active app$:
     result = user.talon_get_active_application_info()
     clip.set_text(result)
+^talon create app context$: user.talon_create_app_context()
 
 talon (bug report | report bug):
     user.open_url("https://github.com/talonhub/community/issues")

--- a/plugin/talon_helpers/talon_helpers.talon
+++ b/plugin/talon_helpers/talon_helpers.talon
@@ -49,7 +49,11 @@ talon dump context:
 ^talon copy active app$:
     result = user.talon_get_active_application_info()
     clip.set_text(result)
+
 ^talon create app context$: user.talon_create_app_context()
+^talon create windows app context$: user.talon_create_app_context("win")
+^talon create linux app context$: user.talon_create_app_context("linux")
+^talon create mac app context$: user.talon_create_app_context("mac")
 
 talon (bug report | report bug):
     user.open_url("https://github.com/talonhub/community/issues")


### PR DESCRIPTION
`"talon create app context"` will generate a new folder in `apps` with a Talon and a python file. 

Example from visual studio code: 

`apps/visual_studio_code/visual_studio_code.talon`
```talon
app: visual_studio_code
-

```

`apps/visual_studio_code/visual_studio_code.py`
```py
from talon import Module, Context, actions

mod = Module()
ctx = Context()

mod.apps.visual_studio_code = r"""
os: windows
and app.exe: Code.exe
"""

ctx.matches = r"""
os: windows
app: visual_studio_code
"""

# @mod.action_class
# class Actions:
```