### PR TITLE
Always stop mouse scroll down using hiss noise in sleep mode

### DIFF
--- a/core/modes/sleep_mode.talon
+++ b/core/modes/sleep_mode.talon
@@ -1,7 +1,9 @@
 mode: sleep
 -
 settings():
-    #stop continuous scroll/gaze scroll with a pop
+    # Stop continuous scroll/gaze scroll with a pop
     user.mouse_enable_pop_stops_scroll = 0
-    #enable pop click with 'control mouse' mode
+    # Enable pop click with 'control mouse' mode
     user.mouse_enable_pop_click = 0
+    # Stop mouse scroll down using hiss noise
+    user.mouse_enable_hiss_scroll = 0


### PR DESCRIPTION
`mouse_enable_hiss_scroll` currently remains on in sleep mode when enabled. This fixes that, replicating the behavior of other noise/mouse settings.