### PR TITLE
libraries GUI common selection

### DIFF
--- a/lang/python/python.talon
+++ b/lang/python/python.talon
@@ -12,6 +12,7 @@ tag(): user.code_functions_common
 tag(): user.code_keywords
 tag(): user.code_libraries
 tag(): user.code_libraries_gui
+tag(): user.code_libraries_gui_showing
 tag(): user.code_operators_array
 tag(): user.code_operators_assignment
 tag(): user.code_operators_bitwise

--- a/lang/tags/library_gui_open.talon
+++ b/lang/tags/library_gui_open.talon
@@ -3,4 +3,5 @@ tag: user.code_libraries_gui_showing
 # The show functions for this have language specific names, e.g. toggle imports for Python
 # but let's use a generic name for the close one. Having it behind this tag allows it to be closed
 # even if your editor isn't visible.
+import cell <number>: user.code_select_library(number - 1, "")
 toggle libraries close: user.code_toggle_libraries()


### PR DESCRIPTION
There is a mechanics for using a GUI to import modules for programming languages.
Unfortunately a selection method (like for common functions) has been missing in the .talon files.
And the actual Tag has been missing for some languages like python in python.talon.

Therefore I have added a generic command into the common library_gui_open.talon file. 
And the tag into the language specific python.talon file.

If this features should be part of a common grammar, this would need to be handled in every defined language.
And additionally the user action function  "code_insert_library" would need to be defined in e.g. python.py
