### PR TITLE
javascript: Add `is [not] nullish` for loose null check

### DIFF
--- a/lang/javascript/javascript.talon
+++ b/lang/javascript/javascript.talon
@@ -27,6 +27,8 @@ settings():
 
 (op | is) strict equal: " === "
 (op | is) strict not equal: " !== "
+is nullish: " == null"
+is not nullish: " != null"
 op null else: " ?? "
 
 state const: "const "


### PR DESCRIPTION
These check whether a LHS is nullish, i.e. null or undefined.

This is intended to complement #1255.