### PR TITLE
Turn code_object_oriented_accessor into list

### DIFF
--- a/lang/csharp/csharp.py
+++ b/lang/csharp/csharp.py
@@ -9,6 +9,7 @@ ctx.lists["user.code_common_function"] = {
     "print": "Console.WriteLine",
     "string": ".ToString",
 }
+ctx.lists["user.code_self"] = ["this"]
 
 
 @ctx.action_class("user")
@@ -119,9 +120,6 @@ class UserActions:
     def code_block():
         actions.insert("{}")
         actions.key("left enter enter up tab")
-
-    def code_self():
-        actions.auto_insert("this")
 
     def code_operator_object_accessor():
         actions.auto_insert(".")

--- a/lang/csharp/csharp.py
+++ b/lang/csharp/csharp.py
@@ -121,9 +121,6 @@ class UserActions:
         actions.insert("{}")
         actions.key("left enter enter up tab")
 
-    def code_operator_object_accessor():
-        actions.auto_insert(".")
-
     def code_insert_null():
         actions.auto_insert("null")
 

--- a/lang/java/java.py
+++ b/lang/java/java.py
@@ -185,9 +185,6 @@ class UserActions:
     def code_operator_bitwise_right_shift_assignment():
         actions.insert(" >>= ")
 
-    def code_operator_object_accessor():
-        actions.insert(".")
-
     def code_insert_null():
         actions.insert("null")
 

--- a/lang/java/java.py
+++ b/lang/java/java.py
@@ -6,6 +6,8 @@ ctx.matches = r"""
 tag: user.java
 """
 
+ctx.lists["user.code_self"] = ["this"]
+
 # Primitive Types
 java_primitive_types = {
     "boolean": "boolean",
@@ -182,9 +184,6 @@ class UserActions:
 
     def code_operator_bitwise_right_shift_assignment():
         actions.insert(" >>= ")
-
-    def code_self():
-        actions.insert("this")
 
     def code_operator_object_accessor():
         actions.insert(".")

--- a/lang/javascript/javascript.py
+++ b/lang/javascript/javascript.py
@@ -70,6 +70,8 @@ ctx.lists["user.code_keyword"] = {
     "yield": "yield ",
 }
 
+ctx.lists["user.code_self"] = ["this"]
+
 
 @ctx.action_class("user")
 class UserActions:
@@ -92,9 +94,6 @@ class UserActions:
     def code_block():
         actions.user.insert_between("{", "}")
         actions.key("enter")
-
-    def code_self():
-        actions.auto_insert("this")
 
     def code_operator_object_accessor():
         actions.auto_insert(".")

--- a/lang/javascript/javascript.py
+++ b/lang/javascript/javascript.py
@@ -95,9 +95,6 @@ class UserActions:
         actions.user.insert_between("{", "}")
         actions.key("enter")
 
-    def code_operator_object_accessor():
-        actions.auto_insert(".")
-
     def code_state_while():
         actions.user.insert_between("while (", ")")
 

--- a/lang/php/php.py
+++ b/lang/php/php.py
@@ -15,12 +15,11 @@ ctx.lists["user.code_type"] = {
     "void": "void",
 }
 
+ctx.lists["user.code_self"] = {"this": "$this"}
+
 
 @ctx.action_class("user")
 class UserActions:
-    def code_self():
-        actions.auto_insert("$this")
-
     def code_operator_object_accessor():
         actions.auto_insert("->")
 

--- a/lang/php/php.py
+++ b/lang/php/php.py
@@ -16,13 +16,15 @@ ctx.lists["user.code_type"] = {
 }
 
 ctx.lists["user.code_self"] = {"this": "$this"}
+ctx.lists["user.code_operator_object_accessor"] = {
+    "arrow": "->",
+    # backwards compatibility
+    "dot": "->",
+}
 
 
 @ctx.action_class("user")
 class UserActions:
-    def code_operator_object_accessor():
-        actions.auto_insert("->")
-
     def code_define_class():
         actions.auto_insert("class ")
 

--- a/lang/python/python.py
+++ b/lang/python/python.py
@@ -59,6 +59,8 @@ ctx.lists["user.code_type"] = {
     "no return": "NoReturn",
 }
 
+ctx.lists["user.code_self"] = ["self"]
+
 ctx.lists["user.code_keyword"] = {
     "break": "break",
     "continue": "continue",
@@ -249,9 +251,6 @@ class UserActions:
 
     def code_operator_bitwise_right_shift_assignment():
         actions.auto_insert(" >>= ")
-
-    def code_self():
-        actions.auto_insert("self")
 
     def code_operator_object_accessor():
         actions.auto_insert(".")

--- a/lang/python/python.py
+++ b/lang/python/python.py
@@ -252,9 +252,6 @@ class UserActions:
     def code_operator_bitwise_right_shift_assignment():
         actions.auto_insert(" >>= ")
 
-    def code_operator_object_accessor():
-        actions.auto_insert(".")
-
     def code_insert_null():
         actions.auto_insert("None")
 

--- a/lang/ruby/ruby.py
+++ b/lang/ruby/ruby.py
@@ -107,9 +107,6 @@ class UserActions:
     def code_operator_bitwise_right_shift_assignment():
         actions.auto_insert(" >>= ")
 
-    def code_operator_object_accessor():
-        actions.auto_insert(".")
-
     def code_insert_null():
         actions.auto_insert("nil")
 

--- a/lang/ruby/ruby.py
+++ b/lang/ruby/ruby.py
@@ -5,6 +5,8 @@ ctx.matches = r"""
 tag: user.ruby
 """
 
+ctx.lists["user.code_self"] = ["self"]
+
 
 @ctx.action_class("user")
 class UserActions:
@@ -104,9 +106,6 @@ class UserActions:
 
     def code_operator_bitwise_right_shift_assignment():
         actions.auto_insert(" >>= ")
-
-    def code_self():
-        actions.auto_insert("self")
 
     def code_operator_object_accessor():
         actions.auto_insert(".")

--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -198,6 +198,9 @@ ctx.lists["user.code_libraries"] = {
     "collections": "std::collections",
 }
 
+# tag: object_oriented
+ctx.lists["user.code_self"] = ["self"]
+
 # tag: functions_common
 ctx.lists["user.code_common_function"] = {
     "drop": "drop",
@@ -298,9 +301,6 @@ class UserActions:
 
     def code_operator_object_accessor():
         actions.auto_insert(".")
-
-    def code_self():
-        actions.auto_insert("self")
 
     def code_define_class():
         actions.auto_insert("struct ")

--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -299,9 +299,6 @@ class UserActions:
 
     # tag: object_oriented
 
-    def code_operator_object_accessor():
-        actions.auto_insert(".")
-
     def code_define_class():
         actions.auto_insert("struct ")
 

--- a/lang/scala/scala.py
+++ b/lang/scala/scala.py
@@ -49,6 +49,8 @@ scala_types = scala_common_types.copy()
 scala_types.update(scala_common_generic_types)
 ctx.lists["user.code_type"] = scala_types
 
+ctx.lists["user.code_self"] = ["this"]
+
 # Scala Modifies
 scala_modifiers = {
     "public": "public",
@@ -184,9 +186,6 @@ class UserActions:
 
     def code_operator_bitwise_right_shift_assignment():
         actions.insert(" >>= ")
-
-    def code_self():
-        actions.insert("this")
 
     def code_insert_null():
         actions.insert("null")

--- a/lang/scala/scala.py
+++ b/lang/scala/scala.py
@@ -272,9 +272,6 @@ class UserActions:
     def code_insert_return_type(type: str):
         actions.insert(f": {type}")
 
-    def code_operator_object_accessor():
-        actions.insert(".")
-
     def code_default_function(text: str):
         """Inserts function declaration"""
         actions.user.code_public_function(text)

--- a/lang/tags/object_oriented.py
+++ b/lang/tags/object_oriented.py
@@ -1,5 +1,6 @@
-from talon import Module
+from talon import Context, Module
 
+ctx = Context()
 mod = Module()
 
 mod.tag(
@@ -11,6 +12,15 @@ mod.list(
     "code_self",
     desc="Reference to the current object (e.g. C++ `this` or Python `self`)",
 )
+
+mod.list(
+    "code_operator_object_accessor",
+    desc="An object accessor operator (e.g. Java `.` or PHP `->`)",
+)
+
+ctx.lists["self.code_operator_object_accessor"] = {
+    "dot": ".",
+}
 
 
 @mod.action_class

--- a/lang/tags/object_oriented.py
+++ b/lang/tags/object_oriented.py
@@ -1,6 +1,5 @@
-from talon import Context, Module
+from talon import Module
 
-ctx = Context()
 mod = Module()
 
 mod.tag(

--- a/lang/tags/object_oriented.py
+++ b/lang/tags/object_oriented.py
@@ -7,14 +7,16 @@ mod.tag(
     desc="Tag for enabling basic object oriented programming commands (objects, classes, etc)",
 )
 
+mod.list(
+    "code_self",
+    desc="Reference to the current object (e.g. C++ `this` or Python `self`)",
+)
+
 
 @mod.action_class
 class Actions:
     def code_operator_object_accessor():
         """Inserts the object accessor operator (e.g., Java's "." or PHP's "->)"""
-
-    def code_self():
-        """Inserts a reference to the current object (e.g., C++ "this" or Python's "self")"""
 
     def code_define_class():
         """Starts a class definition (e.g., Java's "class" keyword)"""

--- a/lang/tags/object_oriented.talon
+++ b/lang/tags/object_oriented.talon
@@ -8,3 +8,6 @@ tag: user.code_object_oriented
 state {user.code_self}: insert(code_self)
 
 state class: user.code_define_class()
+
+{user.code_self} {user.code_operator_object_accessor}:
+    insert("{code_self}{code_operator_object_accessor}")

--- a/lang/tags/object_oriented.talon
+++ b/lang/tags/object_oriented.talon
@@ -1,10 +1,10 @@
 tag: user.code_object_oriented
 -
 
-self dot:
-    user.code_self()
+{user.code_self} dot:
+    insert(code_self)
     user.code_operator_object_accessor()
 
-state self: user.code_self()
+state {user.code_self}: insert(code_self)
 
 state class: user.code_define_class()


### PR DESCRIPTION
This turns the "dot" in `self dot` into a list. This allows for a different phrase to be used to accomodate languages, such as PHP, which don't use `.` to access fields and methods.

This could then be further used to define `code_common_member_function` (and the corresponding `dot <method>` command) in a more appropriate language-agnostic place.

Depends on: #1253
Ref: #664