### PR TITLE
data_null: Turn null into a list

### DIFF
--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -131,6 +131,10 @@ ctx.lists["user.code_common_function"] = {
     "free": "free",
 }
 
+ctx.lists["user.code_data_null"] = {
+    "null": "NULL",
+}
+
 mod.list("c_pointers", desc="Common C pointers")
 mod.list("c_signed", desc="Common C datatype signed modifiers")
 mod.list("c_keywords", desc="C keywords")
@@ -301,9 +305,6 @@ class UserActions:
 
     def code_operator_bitwise_right_shift_assignment():
         actions.auto_insert(" >>= ")
-
-    def code_insert_null():
-        actions.auto_insert("NULL")
 
     def code_insert_is_null():
         actions.auto_insert(" == NULL ")

--- a/lang/csharp/csharp.py
+++ b/lang/csharp/csharp.py
@@ -126,9 +126,6 @@ class UserActions:
     def code_operator_object_accessor():
         actions.auto_insert(".")
 
-    def code_insert_null():
-        actions.auto_insert("null")
-
     def code_insert_is_null():
         actions.auto_insert(" == null ")
 

--- a/lang/java/java.py
+++ b/lang/java/java.py
@@ -189,9 +189,6 @@ class UserActions:
     def code_operator_object_accessor():
         actions.insert(".")
 
-    def code_insert_null():
-        actions.insert("null")
-
     def code_insert_is_null():
         actions.insert(" == null")
 

--- a/lang/javascript/javascript.py
+++ b/lang/javascript/javascript.py
@@ -44,6 +44,8 @@ ctx.lists["user.code_common_member_function"] = {
     "then": "then",
 }
 
+ctx.lists["user.code_data_null"] = ["null", "undefined"]
+
 ctx.lists["user.code_keyword"] = {
     "a sink": "async ",
     "await": "await ",
@@ -140,9 +142,6 @@ class UserActions:
 
     def code_insert_false():
         actions.auto_insert("false")
-
-    def code_insert_null():
-        actions.auto_insert("null")
 
     def code_operator_lambda():
         actions.auto_insert(" => ")

--- a/lang/lua/lua.py
+++ b/lang/lua/lua.py
@@ -14,6 +14,10 @@ mod.setting(
 )
 mod.tag("stylua", desc="Tag for stylua linting commands")
 
+ctx.lists["user.code_data_null"] = {
+    "nil": "nil",
+}
+
 ctx.lists["user.code_common_function"] = {
     "to number": "tonumber",
     "I pairs": "ipairs",
@@ -157,9 +161,6 @@ class UserActions:
     ##
     # code_data_null
     ##
-    def code_insert_null():
-        actions.insert("nil")
-
     def code_insert_is_null():
         actions.insert(" == nil")
 

--- a/lang/php/php.py
+++ b/lang/php/php.py
@@ -61,9 +61,6 @@ class UserActions:
     def code_insert_false():
         actions.auto_insert("false")
 
-    def code_insert_null():
-        actions.auto_insert("null")
-
     def code_insert_is_null():
         actions.auto_insert("is_null()")
         actions.edit.left()

--- a/lang/python/python.py
+++ b/lang/python/python.py
@@ -40,6 +40,8 @@ docstring_fields = {
 mod.list("python_docstring_fields", desc="python docstring fields")
 ctx.lists["user.python_docstring_fields"] = docstring_fields
 
+ctx.lists["user.code_data_null"] = ["None"]
+
 ctx.lists["user.code_type"] = {
     "boolean": "bool",
     "integer": "int",
@@ -255,9 +257,6 @@ class UserActions:
 
     def code_operator_object_accessor():
         actions.auto_insert(".")
-
-    def code_insert_null():
-        actions.auto_insert("None")
 
     def code_insert_is_null():
         actions.auto_insert(" is None")

--- a/lang/r/r.py
+++ b/lang/r/r.py
@@ -6,6 +6,10 @@ ctx.matches = r"""
 tag: user.r
 """
 
+ctx.lists["user.code_data_null"] = {
+    "null": "NULL",
+}
+
 ctx.lists["user.code_common_function"] = {
     # base R
     "as character": "as.character",
@@ -289,9 +293,6 @@ class UserActions:
 
     def code_operator_bitwise_and():
         actions.auto_insert(" & ")
-
-    def code_insert_null():
-        actions.auto_insert("NULL")
 
     def code_state_if():
         actions.insert("if () {}")

--- a/lang/ruby/ruby.py
+++ b/lang/ruby/ruby.py
@@ -5,6 +5,10 @@ ctx.matches = r"""
 tag: user.ruby
 """
 
+ctx.lists["user.code_data_null"] = {
+    "nil": "nil",
+}
+
 
 @ctx.action_class("user")
 class UserActions:
@@ -110,9 +114,6 @@ class UserActions:
 
     def code_operator_object_accessor():
         actions.auto_insert(".")
-
-    def code_insert_null():
-        actions.auto_insert("nil")
 
     def code_insert_is_null():
         actions.auto_insert(".nil?")

--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -189,6 +189,11 @@ all_traits = {
     **iterator_traits,
 }
 
+# tag: data_null
+ctx.lists["user.code_data_null"] = {
+    "none": "None",
+    "null": "ptr::null()",
+}
 
 # tag: libraries_gui
 ctx.lists["user.code_libraries"] = {
@@ -225,7 +230,6 @@ ctx.lists["user.code_type_modifier"] = {
 
 @ctx.capture("user.code_type", rule="[{user.code_type_modifier}] {user.code_type}")
 def code_type(m) -> str:
-    """Returns a macro name"""
     return "".join(m)
 
 
@@ -314,9 +318,6 @@ class UserActions:
         actions.auto_insert("false")
 
     # tag: data_null
-
-    def code_insert_null():
-        actions.auto_insert("None")
 
     def code_insert_is_null():
         actions.auto_insert(".is_none()")

--- a/lang/scala/scala.py
+++ b/lang/scala/scala.py
@@ -188,9 +188,6 @@ class UserActions:
     def code_self():
         actions.insert("this")
 
-    def code_insert_null():
-        actions.insert("null")
-
     def code_insert_is_null():
         actions.insert(" == null")
 

--- a/lang/sql/sql.py
+++ b/lang/sql/sql.py
@@ -5,6 +5,10 @@ ctx.matches = r"""
 tag: user.sql
 """
 
+ctx.lists["user.code_data_null"] = {
+    "null": "NULL",
+}
+
 # these vary by dialect
 ctx.lists["user.code_common_function"] = {"count": "Count", "min": "Min", "max": "Max"}
 
@@ -52,9 +56,6 @@ class UserActions:
 
     def code_operator_or():
         actions.auto_insert("OR ")
-
-    def code_insert_null():
-        actions.auto_insert("NULL")
 
     def code_insert_is_null():
         actions.auto_insert(" IS NULL")

--- a/lang/tags/data_null.py
+++ b/lang/tags/data_null.py
@@ -4,13 +4,18 @@ ctx = Context()
 mod = Module()
 
 mod.tag("code_data_null", desc="Tag for enabling commands relating to null")
+mod.list("code_data_null", desc="null-like value (e.g. Python `None`, C++ `nullptr`)")
+
+ctx.lists["self.code_data_null"] = {
+    "null": "null",
+    # backwards compatibility
+    "nil": "null",
+    "none": "null",
+}
 
 
 @mod.action_class
 class Actions:
-    def code_insert_null():
-        """Inserts null"""
-
     def code_insert_is_null():
         """Inserts check for null"""
 

--- a/lang/tags/data_null.talon
+++ b/lang/tags/data_null.talon
@@ -1,5 +1,5 @@
 tag: user.code_data_null
 -
-state (no | none | nil | null): user.code_insert_null()
+state {user.code_data_null}: insert(code_data_null)
 is not (none | null): user.code_insert_is_not_null()
 is (none | null): user.code_insert_is_null()


### PR DESCRIPTION
The intention here is to accomodate languages that have multiple different null-like values. For example:

- Rust
  - `None` (i.e. the `Option::None` enum)
  - `core::ptr::null()`
- JavaScript
  - `null`
  - `undefined`
- C++
  - `NULL` (from C)
  - `nullptr` (i.e. [`nullptr_t`](https://en.cppreference.com/w/cpp/types/nullptr_t))
  - `std::nullopt` (i.e. the [`std::optional<T>`](https://en.cppreference.com/w/cpp/utility/optional) template)

---

TODO:

- [ ] Make `code_insert_is_(not_)null` accept the null kind (required for Rust to check non-comparable `Option` vs pointer)

Note: This may conflict with #1253/#1254 due to different language implementations defining the actions next to each other.