### PR TITLE
Remove language tags and instead utilize `code.language`

### DIFF
--- a/apps/vscode/snippets/python_snippets.py
+++ b/apps/vscode/snippets/python_snippets.py
@@ -5,7 +5,7 @@ from talon import Context
 ctx = Context()
 ctx.matches = r"""
 app: vscode
-tag: user.python
+code.language: python
 """
 # short name -> ide clip name
 ctx.lists["user.snippets"] = {

--- a/core/modes/language_modes.py
+++ b/core/modes/language_modes.py
@@ -1,8 +1,5 @@
 from talon import Context, Module, actions
 
-ctx = Context()
-mod = Module()
-
 # Maps language mode names to the extensions that activate them. Only put things
 # here which have a supported language mode; that's why there are so many
 # commented out entries. TODO: make this a csv file?
@@ -59,7 +56,20 @@ language_name_overrides = {
     "r": ["are language"],
     "tex": ["tech", "lay tech", "latex"],
 }
+
+mod = Module()
+
+ctx = Context()
+
+ctx_forced = Context()
+ctx_forced.matches = r"""
+tag: user.code_language_forced
+"""
+
+
+mod.tag("code_language_forced", "This tag is active when a language mode is forced")
 mod.list("language_mode", desc="Name of a programming language mode.")
+
 ctx.lists["self.language_mode"] = {
     name: language
     for language in language_extensions
@@ -73,41 +83,36 @@ extension_lang_map = {
     for ext in extensions.split()
 }
 
-# Create a context for each defined language
-for lang in language_extensions.keys():
-    mod.tag(lang)
-    mod.tag(f"{lang}_forced")
-    c = Context()
-    # Context is active if language is forced or auto language matches
-    c.matches = f"""
-    tag: user.{lang}_forced
-    tag: user.auto_lang
-    and code.language: {lang}
-    """
-    c.tags = [f"user.{lang}"]
-
-# Create a mode for the automated language detection. This is active when no lang is forced.
-mod.tag("auto_lang")
-ctx.tags = ["user.auto_lang"]
+forced_language = ""
 
 
 @ctx.action_class("code")
-class code_actions:
+class CodeActions:
     def language():
-        result = ""
         file_extension = actions.win.file_ext()
-        if file_extension and file_extension in extension_lang_map:
-            result = extension_lang_map[file_extension]
-        return result
+        return extension_lang_map.get(file_extension, "")
+
+
+@ctx_forced.action_class("code")
+class ForcedCodeActions:
+    def language():
+        return forced_language
 
 
 @mod.action_class
 class Actions:
     def code_set_language_mode(language: str):
         """Sets the active language mode, and disables extension matching"""
+        global forced_language
         assert language in language_extensions
-        ctx.tags = [f"user.{language}_forced"]
+        forced_language = language
+        # Update tags to force a context refresh. Otherwise `code.language` will not update.
+        # Necessary to first set an empty list otherwise you can't move from one forced language to another.
+        ctx.tags = []
+        ctx.tags = ["user.code_language_forced"]
 
     def code_clear_language_mode():
         """Clears the active language mode, and re-enables code.language: extension matching"""
-        ctx.tags = ["user.auto_lang"]
+        global forced_language
+        forced_language = ""
+        ctx.tags = []

--- a/lang/batch/batch.py
+++ b/lang/batch/batch.py
@@ -2,7 +2,7 @@ from talon import Context, actions
 
 ctx = Context()
 ctx.matches = r"""
-tag: user.batch
+code.language: batch
 """
 
 

--- a/lang/batch/batch.talon
+++ b/lang/batch/batch.talon
@@ -1,4 +1,4 @@
-tag: user.batch
+code.language: batch
 -
 tag(): user.code_comment_line
 

--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -10,7 +10,7 @@ mod.setting(
 
 ctx = Context()
 ctx.matches = r"""
-tag: user.c
+code.language: c
 """
 
 ctx.lists["self.c_pointers"] = {

--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -1,4 +1,4 @@
-tag: user.c
+code.language: c
 -
 tag(): user.code_imperative
 

--- a/lang/csharp/csharp.py
+++ b/lang/csharp/csharp.py
@@ -2,7 +2,7 @@ from talon import Context, actions, settings
 
 ctx = Context()
 ctx.matches = r"""
-tag: user.csharp
+code.language: csharp
 """
 ctx.lists["user.code_common_function"] = {
     "integer": "int.TryParse",

--- a/lang/csharp/csharp.talon
+++ b/lang/csharp/csharp.talon
@@ -1,4 +1,4 @@
-tag: user.csharp
+code.language: csharp
 -
 tag(): user.code_imperative
 tag(): user.code_object_oriented

--- a/lang/css/css.py
+++ b/lang/css/css.py
@@ -4,7 +4,8 @@ mod = Module()
 global_ctx = Context()
 ctx = Context()
 ctx.matches = """
-tag: user.css
+code.language: css
+code.language: scss
 """
 
 mod.list("css_at_rule", desc="List of CSS @rules")

--- a/lang/css/css.talon
+++ b/lang/css/css.talon
@@ -1,4 +1,5 @@
-tag: user.css
+code.language: css
+code.language: scss
 -
 tag(): user.code_comment_block_c_like
 tag(): user.code_functions_common

--- a/lang/css/scss.talon
+++ b/lang/css/scss.talon
@@ -1,3 +1,0 @@
-tag: user.scss
--
-tag(): user.css

--- a/lang/go/go.talon
+++ b/lang/go/go.talon
@@ -1,4 +1,4 @@
-tag: user.go
+code.language: go
 -
 variadic: "..."
 logical and: " && "

--- a/lang/html/html.talon
+++ b/lang/html/html.talon
@@ -1,0 +1,4 @@
+code.language: html
+code.language: javascriptreact
+code.language: typescriptreact
+-

--- a/lang/java/java.py
+++ b/lang/java/java.py
@@ -3,7 +3,7 @@ from talon import Context, Module, actions, settings
 ctx = Context()
 mod = Module()
 ctx.matches = r"""
-tag: user.java
+code.language: java
 """
 
 # Primitive Types

--- a/lang/java/java.talon
+++ b/lang/java/java.talon
@@ -1,4 +1,4 @@
-tag: user.java
+code.language: java
 -
 tag(): user.code_imperative
 tag(): user.code_object_oriented

--- a/lang/javascript/javascript.py
+++ b/lang/javascript/javascript.py
@@ -2,8 +2,11 @@ from talon import Context, Module, actions, settings
 
 mod = Module()
 ctx = Context()
-ctx.matches = """
-tag: user.javascript
+ctx.matches = r"""
+code.language: javascript
+code.language: typescript
+code.language: javascriptreact
+code.language: typescriptreact
 """
 
 ctx.lists["user.code_common_function"] = {

--- a/lang/javascript/javascript.talon
+++ b/lang/javascript/javascript.talon
@@ -1,4 +1,7 @@
-tag: user.javascript
+code.language: javascript
+code.language: typescript
+code.language: javascriptreact
+code.language: typescriptreact
 -
 tag(): user.code_imperative
 tag(): user.code_object_oriented

--- a/lang/javascript/javascriptreact.talon
+++ b/lang/javascript/javascriptreact.talon
@@ -1,3 +1,0 @@
-tag: user.javascriptreact
--
-tag(): user.javascript

--- a/lang/lua/lua.py
+++ b/lang/lua/lua.py
@@ -3,7 +3,7 @@ from talon import Context, Module, actions, settings
 mod = Module()
 ctx = Context()
 ctx.matches = r"""
-tag: user.lua
+code.language: lua
 """
 
 mod.setting(

--- a/lang/lua/lua.talon
+++ b/lang/lua/lua.talon
@@ -1,4 +1,4 @@
-tag: user.lua
+code.language: lua
 -
 
 tag(): user.code_imperative

--- a/lang/lua/stylua.talon
+++ b/lang/lua/stylua.talon
@@ -1,4 +1,4 @@
-code.language: stylua
+tag: user.stylua
 -
 
 lint ignore: "-- stylua: ignore"

--- a/lang/lua/stylua.talon
+++ b/lang/lua/stylua.talon
@@ -1,4 +1,4 @@
-tag: user.stylua
+code.language: stylua
 -
 
 lint ignore: "-- stylua: ignore"

--- a/lang/markdown/markdown.py
+++ b/lang/markdown/markdown.py
@@ -3,6 +3,10 @@ from talon import Context, Module
 mod = Module()
 ctx = Context()
 
+ctx.matches = r"""
+code.language: markdown
+"""
+
 mod.list("markdown_code_block_language", desc="Languages for code blocks")
 ctx.lists["user.markdown_code_block_language"] = {
     "typescript": "typescript",

--- a/lang/markdown/markdown.talon
+++ b/lang/markdown/markdown.talon
@@ -1,4 +1,4 @@
-tag: user.markdown
+code.language: markdown
 -
 (level | heading | header) one:
     edit.line_start()

--- a/lang/php/php.py
+++ b/lang/php/php.py
@@ -2,7 +2,7 @@ from talon import Context, actions, settings
 
 ctx = Context()
 ctx.matches = r"""
-tag: user.php
+code.language: php
 """
 
 ctx.lists["user.code_type"] = {

--- a/lang/php/php.talon
+++ b/lang/php/php.talon
@@ -1,4 +1,4 @@
-tag: user.php
+code.language: php
 -
 tag(): user.code_imperative
 tag(): user.code_object_oriented

--- a/lang/proto/proto.py
+++ b/lang/proto/proto.py
@@ -4,7 +4,7 @@ mod = Module()
 
 ctx = Context()
 ctx.matches = r"""
-tag: user.protobuf
+code.language: protobuf
 """
 
 ctx.lists["user.code_type"] = {

--- a/lang/proto/proto.talon
+++ b/lang/proto/proto.talon
@@ -1,4 +1,4 @@
-tag: user.protobuf
+code.language: protobuf
 -
 
 # this is pretty bare-bones, further contributions welcome

--- a/lang/python/python.py
+++ b/lang/python/python.py
@@ -5,7 +5,7 @@ from talon import Context, Module, actions, settings
 mod = Module()
 ctx = Context()
 ctx.matches = r"""
-tag: user.python
+code.language: python
 """
 ctx.lists["user.code_common_function"] = {
     "enumerate": "enumerate",

--- a/lang/python/python.talon
+++ b/lang/python/python.talon
@@ -1,4 +1,4 @@
-tag: user.python
+code.language: python
 -
 tag(): user.code_imperative
 tag(): user.code_object_oriented

--- a/lang/r/r.py
+++ b/lang/r/r.py
@@ -3,7 +3,7 @@ from talon import Context, actions, settings
 ctx = Context()
 
 ctx.matches = r"""
-tag: user.r
+code.language: r
 """
 
 ctx.lists["user.code_common_function"] = {

--- a/lang/r/r.talon
+++ b/lang/r/r.talon
@@ -1,4 +1,4 @@
-tag: user.r
+code.language: r
 -
 tag(): user.code_imperative
 

--- a/lang/ruby/ruby.py
+++ b/lang/ruby/ruby.py
@@ -2,7 +2,7 @@ from talon import Context, actions, settings
 
 ctx = Context()
 ctx.matches = r"""
-tag: user.ruby
+code.language: ruby
 """
 
 

--- a/lang/ruby/ruby.talon
+++ b/lang/ruby/ruby.talon
@@ -1,4 +1,4 @@
-tag: user.ruby
+code.language: ruby
 -
 tag(): user.code_imperative
 tag(): user.code_object_oriented

--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -50,7 +50,7 @@ class Actions:
 
 ctx = Context()
 ctx.matches = r"""
-tag: user.rust
+code.language: rust
 """
 
 scalar_types = {

--- a/lang/rust/rust.talon
+++ b/lang/rust/rust.talon
@@ -1,4 +1,4 @@
-tag: user.rust
+code.language: rust
 -
 tag(): user.code_comment_line
 tag(): user.code_comment_block_c_like

--- a/lang/scala/scala.py
+++ b/lang/scala/scala.py
@@ -3,7 +3,7 @@ from talon import Context, Module, actions, settings
 ctx = Context()
 mod = Module()
 ctx.matches = r"""
-tag: user.scala
+code.language: scala
 """
 
 # Scala Common Types

--- a/lang/scala/scala.talon
+++ b/lang/scala/scala.talon
@@ -1,4 +1,4 @@
-tag: user.scala
+code.language: scala
 -
 tag(): user.code_imperative
 tag(): user.code_object_oriented

--- a/lang/sql/sql.py
+++ b/lang/sql/sql.py
@@ -2,7 +2,7 @@ from talon import Context, actions
 
 ctx = Context()
 ctx.matches = r"""
-tag: user.sql
+code.language: sql
 """
 
 # these vary by dialect

--- a/lang/sql/sql.talon
+++ b/lang/sql/sql.talon
@@ -1,4 +1,4 @@
-tag: user.sql
+code.language: sql
 -
 tag(): user.code_operators_math
 tag(): user.code_comment_line

--- a/lang/talon/talon.py
+++ b/lang/talon/talon.py
@@ -31,7 +31,7 @@ mod.list("talon_scopes")
 mod.list("talon_modes")
 
 ctx.matches = r"""
-tag: user.talon
+code.language: talon
 """
 ctx.lists["user.code_common_function"] = {
     "insert": "insert",

--- a/lang/talon/talon.talon
+++ b/lang/talon/talon.talon
@@ -1,4 +1,4 @@
-tag: user.talon
+code.language: talon
 -
 tag(): user.code_operators_math
 tag(): user.code_operators_assignment

--- a/lang/terraform/terraform.py
+++ b/lang/terraform/terraform.py
@@ -3,7 +3,7 @@ from talon import Context, Module, actions
 ctx = Context()
 mod = Module()
 ctx.matches = r"""
-tag: user.terraform
+code.language: terraform
 """
 
 types = {

--- a/lang/terraform/terraform.talon
+++ b/lang/terraform/terraform.talon
@@ -1,4 +1,4 @@
-tag: user.terraform
+code.language: terraform
 -
 tag(): user.code_comment_block_c_like
 tag(): user.code_comment_line

--- a/lang/typescript/typescript.py
+++ b/lang/typescript/typescript.py
@@ -2,7 +2,10 @@ from talon import Context, actions, settings
 
 ctx = Context()
 ctx.matches = r"""
-tag: user.typescript
+code.language: typescript
+code.language: typescriptreact
+# Make typescript win over javascript
+mode: command
 """
 
 ctx.lists["user.code_type"] = {

--- a/lang/typescript/typescript.talon
+++ b/lang/typescript/typescript.talon
@@ -1,6 +1,6 @@
-tag: user.typescript
+code.language: typescript
+code.language: typescriptreact
 -
-tag(): user.javascript
 
 type union [<user.code_type>]: " | {code_type or ''}"
 type intersect [<user.code_type>]: " & {code_type or ''}"

--- a/lang/typescript/typescriptreact.talon
+++ b/lang/typescript/typescriptreact.talon
@@ -1,4 +1,0 @@
-tag: user.typescriptreact
--
-tag(): user.typescript
-tag(): user.javascriptreact

--- a/lang/vimscript/vimscript.py
+++ b/lang/vimscript/vimscript.py
@@ -3,7 +3,7 @@ from talon import Context, Module, actions
 mod = Module()
 ctx = Context()
 ctx.matches = r"""
-tag: user.vimscript
+code.language: vimscript
 """
 
 ctx.lists["self.vimscript_functions"] = {

--- a/lang/vimscript/vimscript.talon
+++ b/lang/vimscript/vimscript.talon
@@ -1,4 +1,4 @@
-tag: user.vimscript
+code.language: vimscript
 -
 tag(): user.code_imperative
 tag(): user.code_operators_assignment


### PR DESCRIPTION
Removed our hack with language tags and instead rely on the Talon defined `code.language`

From
```
tag: user.c
-
```

to
```
code.language: c
-
```
