### PR TITLE
Add capability to focus window by title

### DIFF
--- a/core/app_switcher/app_switcher.py
+++ b/core/app_switcher/app_switcher.py
@@ -3,6 +3,7 @@ import shlex
 import subprocess
 import time
 from pathlib import Path
+import re
 
 import talon
 from talon import Context, Module, actions, app, fs, imgui, ui
@@ -315,6 +316,16 @@ class Actions:
             if time.perf_counter() - t1 > 1:
                 raise RuntimeError(f"Can't focus app: {app.name}")
             actions.sleep(0.1)
+
+    def switcher_focus_app_title(app: str, regex: str):
+        """Focus the window whose app name constains app and title matches regex"""
+        for window in ui.windows():
+            if not(window.hidden) and (app in window.app.name or app == "*") and window.title != "":
+                # logging.warn(f'Checking Window: "{window.app.name}" window:"{window.title}" hidden: "{window.hidden}"')
+                if (regex is None or re.search(regex, window.title)):
+                    window.focus()
+                    return
+        logging.error(f'(switcher_focus_app_title) Window not found: "{app}" "{regex}"')
 
     def switcher_focus_window(window: ui.Window):
         """Focus window and wait until switch is made"""

--- a/core/app_switcher/app_switcher.py
+++ b/core/app_switcher/app_switcher.py
@@ -1,9 +1,9 @@
 import os
+import re
 import shlex
 import subprocess
 import time
 from pathlib import Path
-import re
 
 import talon
 from talon import Context, Module, actions, app, fs, imgui, ui
@@ -320,9 +320,13 @@ class Actions:
     def switcher_focus_app_title(app: str, regex: str):
         """Focus the window whose app name constains app and title matches regex"""
         for window in ui.windows():
-            if not(window.hidden) and (app in window.app.name or app == "*") and window.title != "":
+            if (
+                not (window.hidden)
+                and (app in window.app.name or app == "*")
+                and window.title != ""
+            ):
                 # logging.warn(f'Checking Window: "{window.app.name}" window:"{window.title}" hidden: "{window.hidden}"')
-                if (regex is None or re.search(regex, window.title)):
+                if regex is None or re.search(regex, window.title):
                     window.focus()
                     return
         logging.error(f'(switcher_focus_app_title) Window not found: "{app}" "{regex}"')

--- a/core/windows_and_tabs/window_management.talon
+++ b/core/windows_and_tabs/window_management.talon
@@ -4,6 +4,7 @@ window last: app.window_previous()
 window close: app.window_close()
 window hide: app.window_hide()
 focus <user.running_applications>: user.switcher_focus(running_applications)
+focus title <phrase>: user.switcher_focus_app_title("*", "{phrase}")
 # following only works on windows. Can't figure out how to make it work for mac. No idea what the equivalent for linux would be.
 focus$: user.switcher_menu()
 running list: user.switcher_toggle_running()


### PR DESCRIPTION
# Problem
When an app has multiple windows focus just picks the first one it fights, which may not be the desired one, and there is not a great way to focus just the window you want.

# Solution
Add a new method, switcher_focus_app_title, to app_switcher.py that will focus the window whose title matches a given app name and a given regular expression. Also added a command to that will focus a window with a given spoken phrase.

# Testing
Verified working in current windows eleven environment.