### PR TITLE
Added simplified spoken forms for window snap

### DIFF
--- a/core/windows_and_tabs/window_snap.py
+++ b/core/windows_and_tabs/window_snap.py
@@ -290,7 +290,7 @@ class Actions:
         See `RelativeScreenPos` for the structure of this position."""
         _snap_window_helper(ui.active_window(), pos)
 
-    def snap_window_to_position(pos_name: str) -> None:
+    def snap_window_to_position(position_name: str) -> None:
         """Move the active window to a specifically named position on its current screen, using a key from `_snap_positions`."""
         actions.user.snap_window(_snap_positions[pos_name])
 

--- a/core/windows_and_tabs/window_snap.py
+++ b/core/windows_and_tabs/window_snap.py
@@ -255,7 +255,7 @@ _snap_positions = {
     "bottom left two thirds": RelativeScreenPos(0, 0.5, 2 / 3, 1),
     "bottom right two thirds": RelativeScreenPos(1 / 3, 0.5, 1, 1),
     "bottom center third": RelativeScreenPos(1 / 3, 0.5, 2 / 3, 1),
-    # Alternate spoken forms ford sixths
+    # Alternate spoken forms for sixths
     "top left small": RelativeScreenPos(0, 0, 1 / 3, 0.5),
     "top right small": RelativeScreenPos(2 / 3, 0, 1, 0.5),
     "top left large": RelativeScreenPos(0, 0, 2 / 3, 0.5),

--- a/core/windows_and_tabs/window_snap.py
+++ b/core/windows_and_tabs/window_snap.py
@@ -227,7 +227,7 @@ _snap_positions = {
     "right third": RelativeScreenPos(2 / 3, 0, 1, 1),
     "left two thirds": RelativeScreenPos(0, 0, 2 / 3, 1),
     "right two thirds": RelativeScreenPos(1 / 3, 0, 1, 1),
-    # Alternate spoken forms for thirds
+    # Alternate (simpler) spoken forms for thirds
     "center small": RelativeScreenPos(1 / 3, 0, 2 / 3, 1),
     "left small": RelativeScreenPos(0, 0, 1 / 3, 1),
     "right small": RelativeScreenPos(2 / 3, 0, 1, 1),

--- a/core/windows_and_tabs/window_snap.py
+++ b/core/windows_and_tabs/window_snap.py
@@ -304,11 +304,11 @@ class Actions:
         """Move the active window leftward by one."""
         _move_to_screen(ui.active_window(), screen_number=screen_number)
 
-    def snap_app(app_name: str, pos: RelativeScreenPos):
+    def snap_app(app_name: str, position: RelativeScreenPos):
         """Snap a specific application to another screen."""
         window = _get_app_window(app_name)
         _bring_forward(window)
-        _snap_window_helper(window, pos)
+        _snap_window_helper(window, position)
 
     def move_app_to_screen(app_name: str, screen_number: int):
         """Move a specific application to another screen."""

--- a/core/windows_and_tabs/window_snap.py
+++ b/core/windows_and_tabs/window_snap.py
@@ -291,7 +291,7 @@ class Actions:
         _snap_window_helper(ui.active_window(), pos)
 
     def snap_window_to_position(pos_name: str) -> None:
-        """Move the active window to a named position on-screen."""
+        """Move the active window to a specifically named position on its current screen, using a key from `_snap_positions`."""
         actions.user.snap_window(_snap_positions[pos_name])
 
     def move_window_next_screen() -> None:

--- a/core/windows_and_tabs/window_snap.py
+++ b/core/windows_and_tabs/window_snap.py
@@ -255,7 +255,7 @@ _snap_positions = {
     "bottom left two thirds": RelativeScreenPos(0, 0.5, 2 / 3, 1),
     "bottom right two thirds": RelativeScreenPos(1 / 3, 0.5, 1, 1),
     "bottom center third": RelativeScreenPos(1 / 3, 0.5, 2 / 3, 1),
-    # Alternate spoken forms for sixths
+    # Alternate (simpler) spoken forms for sixths
     "top left small": RelativeScreenPos(0, 0, 1 / 3, 0.5),
     "top right small": RelativeScreenPos(2 / 3, 0, 1, 0.5),
     "top left large": RelativeScreenPos(0, 0, 2 / 3, 0.5),

--- a/core/windows_and_tabs/window_snap.py
+++ b/core/windows_and_tabs/window_snap.py
@@ -285,7 +285,7 @@ ctx.lists["user.window_snap_positions"] = _snap_positions.keys()
 @mod.action_class
 class Actions:
     def snap_window(position: RelativeScreenPos) -> None:
-        """Move the active window to a specific position on-screen.
+        """Move the active window to a specific position on its current screen, given a `RelativeScreenPos` object.
 
         See `RelativeScreenPos` for the structure of this position."""
         _snap_window_helper(ui.active_window(), position)

--- a/core/windows_and_tabs/window_snap.py
+++ b/core/windows_and_tabs/window_snap.py
@@ -313,7 +313,6 @@ class Actions:
     def move_app_to_screen(app_name: str, screen_number: int):
         """Move a specific application to another screen."""
         window = _get_app_window(app_name)
-        print(window)
         _bring_forward(window)
         _move_to_screen(
             window,

--- a/core/windows_and_tabs/window_snap.py
+++ b/core/windows_and_tabs/window_snap.py
@@ -226,12 +226,13 @@ _snap_positions = {
     "left third": RelativeScreenPos(0, 0, 1 / 3, 1),
     "right third": RelativeScreenPos(2 / 3, 0, 1, 1),
     "left two thirds": RelativeScreenPos(0, 0, 2 / 3, 1),
-    "right two thirds": RelativeScreenPos(
-        1 / 3,
-        0,
-        1,
-        1,
-    ),
+    "right two thirds": RelativeScreenPos(1 / 3, 0, 1, 1),
+    # Alternate spoken forms for thirds
+    "center small": RelativeScreenPos(1 / 3, 0, 2 / 3, 1),
+    "left small": RelativeScreenPos(0, 0, 1 / 3, 1),
+    "right small": RelativeScreenPos(2 / 3, 0, 1, 1),
+    "left large": RelativeScreenPos(0, 0, 2 / 3, 1),
+    "right large": RelativeScreenPos(1 / 3, 0, 1, 1),
     # Quarters
     # .---.---.
     # |---|---|
@@ -254,6 +255,17 @@ _snap_positions = {
     "bottom left two thirds": RelativeScreenPos(0, 0.5, 2 / 3, 1),
     "bottom right two thirds": RelativeScreenPos(1 / 3, 0.5, 1, 1),
     "bottom center third": RelativeScreenPos(1 / 3, 0.5, 2 / 3, 1),
+    # Alternate spoken forms ford sixths
+    "top left small": RelativeScreenPos(0, 0, 1 / 3, 0.5),
+    "top right small": RelativeScreenPos(2 / 3, 0, 1, 0.5),
+    "top left large": RelativeScreenPos(0, 0, 2 / 3, 0.5),
+    "top right large": RelativeScreenPos(1 / 3, 0, 1, 0.5),
+    "top center small": RelativeScreenPos(1 / 3, 0, 2 / 3, 0.5),
+    "bottom left small": RelativeScreenPos(0, 0.5, 1 / 3, 1),
+    "bottom right small": RelativeScreenPos(2 / 3, 0.5, 1, 1),
+    "bottom left large": RelativeScreenPos(0, 0.5, 2 / 3, 1),
+    "bottom right large": RelativeScreenPos(1 / 3, 0.5, 1, 1),
+    "bottom center small": RelativeScreenPos(1 / 3, 0.5, 2 / 3, 1),
     # Special
     "center": RelativeScreenPos(1 / 8, 1 / 6, 7 / 8, 5 / 6),
     "full": RelativeScreenPos(0, 0, 1, 1),
@@ -275,10 +287,12 @@ class Actions:
     def snap_window(pos: RelativeScreenPos) -> None:
         """Move the active window to a specific position on-screen.
 
-        See `RelativeScreenPos` for the structure of this position.
-
-        """
+        See `RelativeScreenPos` for the structure of this position."""
         _snap_window_helper(ui.active_window(), pos)
+
+    def snap_window_to_position(pos_name: str) -> None:
+        """Move the active window to a named position on-screen."""
+        actions.user.snap_window(_snap_positions[pos_name])
 
     def move_window_next_screen() -> None:
         """Move the active window to a specific screen."""

--- a/core/windows_and_tabs/window_snap.py
+++ b/core/windows_and_tabs/window_snap.py
@@ -288,7 +288,7 @@ class Actions:
         """Move the active window to a specific position on-screen.
 
         See `RelativeScreenPos` for the structure of this position."""
-        _snap_window_helper(ui.active_window(), pos)
+        _snap_window_helper(ui.active_window(), position)
 
     def snap_window_to_position(position_name: str) -> None:
         """Move the active window to a specifically named position on its current screen, using a key from `_snap_positions`."""

--- a/core/windows_and_tabs/window_snap.py
+++ b/core/windows_and_tabs/window_snap.py
@@ -285,9 +285,7 @@ ctx.lists["user.window_snap_positions"] = _snap_positions.keys()
 @mod.action_class
 class Actions:
     def snap_window(position: RelativeScreenPos) -> None:
-        """Move the active window to a specific position on its current screen, given a `RelativeScreenPos` object.
-
-        See `RelativeScreenPos` for the structure of this position."""
+        """Move the active window to a specific position on its current screen, given a `RelativeScreenPos` object."""
         _snap_window_helper(ui.active_window(), position)
 
     def snap_window_to_position(position_name: str) -> None:

--- a/core/windows_and_tabs/window_snap.py
+++ b/core/windows_and_tabs/window_snap.py
@@ -284,7 +284,7 @@ ctx.lists["user.window_snap_positions"] = _snap_positions.keys()
 
 @mod.action_class
 class Actions:
-    def snap_window(pos: RelativeScreenPos) -> None:
+    def snap_window(position: RelativeScreenPos) -> None:
         """Move the active window to a specific position on-screen.
 
         See `RelativeScreenPos` for the structure of this position."""

--- a/core/windows_and_tabs/window_snap.py
+++ b/core/windows_and_tabs/window_snap.py
@@ -292,7 +292,7 @@ class Actions:
 
     def snap_window_to_position(position_name: str) -> None:
         """Move the active window to a specifically named position on its current screen, using a key from `_snap_positions`."""
-        actions.user.snap_window(_snap_positions[pos_name])
+        actions.user.snap_window(_snap_positions[position_name])
 
     def move_window_next_screen() -> None:
         """Move the active window to a specific screen."""


### PR DESCRIPTION
The existing snap spoken forms are rather verbose, requiring the user to think in terms of fractions.

In day-to-day use, I find it helpful to have "small" and "large" as shorter/simpler aliases. Let's add these as alternates; people can continue to use the old forms if they prefer them.

`"left third"` => `"left small"`
`"bottom right two thirds"` => `"bottom right large"`

I also added an action that takes the position name as a string, instead of the dataclass. This allows users to snap to a specific window position from a Talon file, which wasn't previously possible since you couldn't pass the `RelativeScreenPos` object from Talonscript (this was requested from a few users before).

`user.snap_window_to_position(position_name: str)`
