### PR TITLE
Added Talon based implementation for `app.window_previous/next`

### DIFF
--- a/core/windows_and_tabs/windows_and_tabs.py
+++ b/core/windows_and_tabs/windows_and_tabs.py
@@ -1,0 +1,48 @@
+from talon import Context, actions, ui
+
+ctx = Context()
+
+
+@ctx.action_class("app")
+class AppActions:
+    def window_previous():
+        cycle_windows(ui.active_app(), -1)
+
+    def window_next():
+        cycle_windows(ui.active_app(), 1)
+
+
+def cycle_windows(app: ui.App, diff: int):
+    """Cycle windows backwards or forwards for the given application"""
+    active = app.active_window
+    windows = [w for w in app.windows() if w == active or is_window_valid(w)]
+    windows.sort(key=lambda w: w.id)
+    current = windows.index(active)
+    max = len(windows) - 1
+    i = cycle(current + diff, 0, max)
+
+    while i != current:
+        try:
+            actions.user.switcher_focus_window(windows[i])
+            break
+        except Exception:
+            i = cycle(i + diff, 0, max)
+
+
+def is_window_valid(window: ui.Window) -> bool:
+    """Returns true if this window is valid for focusing"""
+    return (
+        not window.hidden
+        and window.title != ""
+        and window.rect.width > window.screen.dpi
+        and window.rect.height > window.screen.dpi
+    )
+
+
+def cycle(value: int, min: int, max: int) -> int:
+    """Cycle value between minimum and maximum"""
+    if value < min:
+        return max
+    if value > max:
+        return min
+    return value

--- a/core/windows_and_tabs/windows_and_tabs.py
+++ b/core/windows_and_tabs/windows_and_tabs.py
@@ -18,15 +18,14 @@ def cycle_windows(app: ui.App, diff: int):
     windows = [w for w in app.windows() if w == active or is_window_valid(w)]
     windows.sort(key=lambda w: w.id)
     current = windows.index(active)
-    max = len(windows) - 1
-    i = cycle(current + diff, 0, max)
+    i = (current + diff) % len(windows)
 
     while i != current:
         try:
             actions.user.switcher_focus_window(windows[i])
             break
         except Exception:
-            i = cycle(i + diff, 0, max)
+            i = (i + diff) % len(windows)
 
 
 def is_window_valid(window: ui.Window) -> bool:
@@ -39,12 +38,3 @@ def is_window_valid(window: ui.Window) -> bool:
         and window.rect.width > window.screen.dpi
         and window.rect.height > window.screen.dpi
     )
-
-
-def cycle(value: int, min: int, max: int) -> int:
-    """Cycle value between minimum and maximum"""
-    if value < min:
-        return max
-    if value > max:
-        return min
-    return value

--- a/core/windows_and_tabs/windows_and_tabs_linux.py
+++ b/core/windows_and_tabs/windows_and_tabs_linux.py
@@ -35,7 +35,6 @@ class AppActions:
 
     def window_hide_others():
         actions.key("win-d alt-tab")
-        # requires easy window switcher or equivalent (built into most Linux)
 
     def window_open():
         actions.key("ctrl-n")

--- a/core/windows_and_tabs/windows_and_tabs_linux.py
+++ b/core/windows_and_tabs/windows_and_tabs_linux.py
@@ -39,4 +39,3 @@ class AppActions:
 
     def window_open():
         actions.key("ctrl-n")
-        # requires easy window switcher or equivalent (built into most Linux)

--- a/core/windows_and_tabs/windows_and_tabs_linux.py
+++ b/core/windows_and_tabs/windows_and_tabs_linux.py
@@ -37,12 +37,6 @@ class AppActions:
         actions.key("win-d alt-tab")
         # requires easy window switcher or equivalent (built into most Linux)
 
-    def window_next():
-        actions.key("alt-`")
-
     def window_open():
         actions.key("ctrl-n")
         # requires easy window switcher or equivalent (built into most Linux)
-
-    def window_previous():
-        actions.key("alt-shift-`")

--- a/core/windows_and_tabs/windows_and_tabs_mac.py
+++ b/core/windows_and_tabs/windows_and_tabs_mac.py
@@ -35,11 +35,5 @@ class AppActions:
     def window_hide_others():
         actions.key("cmd-alt-h")
 
-    def window_next():
-        actions.key("cmd-`")
-
     def window_open():
         actions.key("cmd-n")
-
-    def window_previous():
-        actions.key("cmd-shift-`")

--- a/core/windows_and_tabs/windows_and_tabs_mac.py
+++ b/core/windows_and_tabs/windows_and_tabs_mac.py
@@ -37,3 +37,9 @@ class AppActions:
 
     def window_open():
         actions.key("cmd-n")
+
+    def window_previous():
+        actions.key("cmd-shift-`")
+
+    def window_next():
+        actions.key("cmd-`")

--- a/core/windows_and_tabs/windows_and_tabs_win.py
+++ b/core/windows_and_tabs/windows_and_tabs_win.py
@@ -35,7 +35,6 @@ class AppActions:
 
     def window_hide_others():
         actions.key("win-d alt-tab")
-        # requires easy window switcher or equivalent (built into most Linux)
 
     def window_open():
         actions.key("ctrl-n")

--- a/core/windows_and_tabs/windows_and_tabs_win.py
+++ b/core/windows_and_tabs/windows_and_tabs_win.py
@@ -39,4 +39,3 @@ class AppActions:
 
     def window_open():
         actions.key("ctrl-n")
-        # requires easy window switcher or equivalent (built into most Linux)

--- a/core/windows_and_tabs/windows_and_tabs_win.py
+++ b/core/windows_and_tabs/windows_and_tabs_win.py
@@ -37,12 +37,6 @@ class AppActions:
         actions.key("win-d alt-tab")
         # requires easy window switcher or equivalent (built into most Linux)
 
-    def window_next():
-        actions.key("alt-`")
-
     def window_open():
         actions.key("ctrl-n")
         # requires easy window switcher or equivalent (built into most Linux)
-
-    def window_previous():
-        actions.key("alt-shift-`")


### PR DESCRIPTION
The current implementation of "window next/last" doesn't really work. This is an implementation using the Talon ui/window api similar to how focusing applications works.
