### PR TITLE
Hide cmd window for mintty when setting cyg_path.

### DIFF
--- a/apps/mintty/mintty_win.py
+++ b/apps/mintty/mintty_win.py
@@ -37,8 +37,10 @@ setting_cyg_path = mod.setting(
 def get_win_path(cyg_path):
     path = ""
     try:
+        si = subprocess.STARTUPINFO()
+        si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
         path = (
-            subprocess.check_output([setting_cyg_path.get(), "-w", cyg_path])
+            subprocess.check_output([setting_cyg_path.get(), "-w", cyg_path], startupinfo=si)
             .strip(b"\n")
             .decode()
         )

--- a/apps/mintty/mintty_win.py
+++ b/apps/mintty/mintty_win.py
@@ -40,7 +40,9 @@ def get_win_path(cyg_path):
         si = subprocess.STARTUPINFO()
         si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
         path = (
-            subprocess.check_output([setting_cyg_path.get(), "-w", cyg_path], startupinfo=si)
+            subprocess.check_output(
+                [setting_cyg_path.get(), "-w", cyg_path], startupinfo=si
+            )
             .strip(b"\n")
             .decode()
         )


### PR DESCRIPTION
The cmd.exe window that the subprocess module uses does not start hidden, and so steals focus from the mintty window.  This focus stealing may happen several times.

The stolen focus is not restored unless Talon sets the focus via the focus command, and inhibits usage of physical input devices until that focus is restored.