### PR TITLE
Add PhpStorm to Jetbrains App List

### DIFF
--- a/apps/jetbrains/jetbrains.py
+++ b/apps/jetbrains/jetbrains.py
@@ -116,6 +116,7 @@ mod = Module()
 mod.apps.jetbrains = "app.name: /jetbrains/"
 mod.apps.jetbrains = "app.name: CLion"
 mod.apps.jetbrains = "app.name: IntelliJ IDEA"
+mod.apps.jetbrains = "app.name: PhpStorm"
 mod.apps.jetbrains = "app.name: PyCharm"
 mod.apps.jetbrains = "app.name: WebStorm"
 mod.apps.jetbrains = "app.name: RubyMine"


### PR DESCRIPTION
I noticed PhpStorm isn't recognized as a JetBrains editor on my Mac, so I added it.