### PR TITLE
Don't report error for self parameter name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,6 @@ pythonpath = [
     ".",
     "test/stubs",
 ]
+
+[tool.pyright]
+reportSelfClsParameterName = false


### PR DESCRIPTION
Suppresses `Instance methods should take a "self" parameter` warnings in editors that use pyright (eg VSCode). Due to the way Talon defines action classes, these warnings are almost always noise in any Talon user file set