### PR TITLE
Added another way to define return types in Java functions

### DIFF
--- a/lang/java/java.py
+++ b/lang/java/java.py
@@ -256,7 +256,7 @@ class UserActions:
             return_type,
             actions.user.formatted_text(
                 text, settings.get("user.code_private_function_formatter")
-            )
+            ),
         )
 
         actions.user.code_insert_function(result, None)
@@ -267,7 +267,7 @@ class UserActions:
             return_type,
             actions.user.formatted_text(
                 text, settings.get("user.code_private_function_formatter")
-            )
+            ),
         )
 
         actions.user.code_insert_function(result, None)
@@ -277,7 +277,7 @@ class UserActions:
             return_type,
             actions.user.formatted_text(
                 text, settings.get("user.code_protected_function_formatter")
-            )
+            ),
         )
 
         actions.user.code_insert_function(result, None)
@@ -287,7 +287,7 @@ class UserActions:
             return_type,
             actions.user.formatted_text(
                 text, settings.get("user.code_protected_function_formatter")
-            )
+            ),
         )
 
         actions.user.code_insert_function(result, None)
@@ -297,7 +297,7 @@ class UserActions:
             return_type,
             actions.user.formatted_text(
                 text, settings.get("user.code_public_function_formatter")
-            )
+            ),
         )
 
         actions.user.code_insert_function(result, None)
@@ -307,8 +307,7 @@ class UserActions:
             return_type,
             actions.user.formatted_text(
                 text, settings.get("user.code_public_function_formatter")
-            )
+            ),
         )
 
         actions.user.code_insert_function(result, None)
-    

--- a/lang/java/java.py
+++ b/lang/java/java.py
@@ -250,9 +250,10 @@ class UserActions:
         actions.user.paste(text)
         actions.edit.left()
 
-    def code_private_function(text: str):
+    def code_private_function(return_type: str, text: str):
         """Inserts private function declaration"""
-        result = "private void {}".format(
+        result = "private {} {}".format(
+            return_type,
             actions.user.formatted_text(
                 text, settings.get("user.code_private_function_formatter")
             )
@@ -260,9 +261,10 @@ class UserActions:
 
         actions.user.code_insert_function(result, None)
 
-    def code_private_static_function(text: str):
+    def code_private_static_function(return_type: str, text: str):
         """Inserts private static function"""
-        result = "private static void {}".format(
+        result = "private static {} {}".format(
+            return_type,
             actions.user.formatted_text(
                 text, settings.get("user.code_private_function_formatter")
             )
@@ -270,8 +272,9 @@ class UserActions:
 
         actions.user.code_insert_function(result, None)
 
-    def code_protected_function(text: str):
-        result = "void {}".format(
+    def code_protected_function(return_type: str, text: str):
+        result = "protected {} {}".format(
+            return_type,
             actions.user.formatted_text(
                 text, settings.get("user.code_protected_function_formatter")
             )
@@ -279,8 +282,9 @@ class UserActions:
 
         actions.user.code_insert_function(result, None)
 
-    def code_protected_static_function(text: str):
-        result = "static void {}".format(
+    def code_protected_static_function(return_type: str, text: str):
+        result = "protected static {} {}".format(
+            return_type,
             actions.user.formatted_text(
                 text, settings.get("user.code_protected_function_formatter")
             )
@@ -288,8 +292,9 @@ class UserActions:
 
         actions.user.code_insert_function(result, None)
 
-    def code_public_function(text: str):
-        result = "public void {}".format(
+    def code_public_function(return_type: str, text: str):
+        result = "public {} {}".format(
+            return_type,
             actions.user.formatted_text(
                 text, settings.get("user.code_public_function_formatter")
             )
@@ -297,11 +302,13 @@ class UserActions:
 
         actions.user.code_insert_function(result, None)
 
-    def code_public_static_function(text: str):
-        result = "public static void {}".format(
+    def code_public_static_function(return_type: str, text: str):
+        result = "public static {} {}".format(
+            return_type,
             actions.user.formatted_text(
                 text, settings.get("user.code_public_function_formatter")
             )
         )
 
         actions.user.code_insert_function(result, None)
+    

--- a/lang/tags/functions.py
+++ b/lang/tags/functions.py
@@ -46,7 +46,7 @@ setting_public_variable_formatter = mod.setting("code_public_variable_formatter"
 
 @mod.action_class
 class Actions:
-    def code_modified_function(modifiers: Union[list[str], int], text: str):
+    def code_modified_function(modifiers: Union[list[str], int], return_type: str, text: str):
         """
         Inserts function declaration with the given modifiers. modifiers == 0
         implies no modifiers (.talon files don't have empty list literal
@@ -57,19 +57,19 @@ class Actions:
         if mods == {}:
             return actions.user.code_default_function(text)
         elif mods == {"static"}:
-            return actions.user.code_private_static_function(text)
+            return actions.user.code_private_static_function(return_type, text)
         elif mods == {"private"}:
-            return actions.user.code_private_function(text)
+            return actions.user.code_private_function(return_type, text)
         elif mods == {"private", "static"}:
-            return actions.user.code_private_static_function(text)
+            return actions.user.code_private_static_function(return_type, text)
         elif mods == {"protected"}:
-            return actions.user.code_protected_function(text)
+            return actions.user.code_protected_function(return_type, text)
         elif mods == {"protected", "static"}:
-            return actions.user.code_protected_static_function(text)
+            return actions.user.code_protected_static_function(return_type, text)
         elif mods == {"public"}:
-            return actions.user.code_public_function(text)
+            return actions.user.code_public_function(return_type, text)
         elif mods == {"public", "static"}:
-            return actions.user.code_public_static_function(text)
+            return actions.user.code_public_static_function(return_type, text)
         else:
             raise RuntimeError(f"Unhandled modifier set: {mods}")
 
@@ -77,22 +77,22 @@ class Actions:
         """Inserts function declaration"""
         actions.user.code_private_function(text)
 
-    def code_private_function(text: str):
+    def code_private_function(return_type: str, text: str):
         """Inserts private function declaration"""
 
-    def code_private_static_function(text: str):
+    def code_private_static_function(return_type: str, text: str):
         """Inserts private static function"""
 
-    def code_protected_function(text: str):
+    def code_protected_function(return_type: str, text: str):
         """Inserts protected function declaration"""
 
-    def code_protected_static_function(text: str):
+    def code_protected_static_function(return_type: str, text: str):
         """Inserts public function"""
 
-    def code_public_function(text: str):
+    def code_public_function(return_type: str, text: str):
         """Inserts public function"""
 
-    def code_public_static_function(text: str):
+    def code_public_static_function(return_type: str, text: str):
         """Inserts public function"""
 
     def code_private_function_formatter(name: str):

--- a/lang/tags/functions.py
+++ b/lang/tags/functions.py
@@ -46,7 +46,9 @@ setting_public_variable_formatter = mod.setting("code_public_variable_formatter"
 
 @mod.action_class
 class Actions:
-    def code_modified_function(modifiers: Union[list[str], int], return_type: str, text: str):
+    def code_modified_function(
+        modifiers: Union[list[str], int], return_type: str, text: str
+    ):
         """
         Inserts function declaration with the given modifiers. modifiers == 0
         implies no modifiers (.talon files don't have empty list literal

--- a/lang/tags/functions.talon
+++ b/lang/tags/functions.talon
@@ -15,8 +15,8 @@ tag: user.code_functions
 #   * pro static funky -> code_protected_static_function
 #   * pub static funky -> code_public_static_function
 #
-^{user.code_function_modifier}* funky <user.text>$:
-    user.code_modified_function(code_function_modifier_list or 0, text)
+^{user.code_function_modifier}* [<user.code_type>] funky <user.text>$:
+    user.code_modified_function(code_function_modifier_list or 0, code_type or "void", text)
 
 # for annotating function parameters
 is type <user.code_type>: user.code_insert_type_annotation(code_type)


### PR DESCRIPTION
Added ability to define return types in Java when creating a function. Currently, the return types are always void. The previous way of defining functions still works too.

example: I can now say "private static String funky myFunction" and the result will be:
`private static String myFunction()`

Feedback is highly appreciated!