### PR TITLE
Add recognition for ESR versions of Firefox

### DIFF
--- a/apps/firefox/firefox.py
+++ b/apps/firefox/firefox.py
@@ -6,6 +6,7 @@ apps = mod.apps
 apps.firefox = "app.name: Firefox"
 apps.firefox = "app.name: Firefox Developer Edition"
 apps.firefox = "app.name: firefox"
+apps.firefox = "app.name: Firefox-esr"
 apps.firefox = """
 os: windows
 and app.name: Firefox


### PR DESCRIPTION
Pretty self-explanatory. This was needed for Talon to recognize the Firefox binary from the stable Debian repository, which is an extended support release version.  