### PR TITLE
lang/go: redo from scratch

### DIFF
--- a/BREAKING_CHANGES.txt
+++ b/BREAKING_CHANGES.txt
@@ -6,6 +6,7 @@ applied given the delay between changes being submitted and the time they were r
 and merged.
 
 ---
+* 2023-11-11 Old go bindings were removed and new ones were added that follow the standards for other languages
 * 2023-06-06 Deprecate `go marks` command for VSCode. Use 'bar marks' instead.
 * 2023-02-04 Deprecate `murder` command for i3wm. Use 'win kill' instead.
 * 2022-12-11 Deprecate user.insert_with_history. Just use `user.add_phrase_to_history(text);

--- a/lang/go/code-common-functions.talon-list
+++ b/lang/go/code-common-functions.talon-list
@@ -1,0 +1,20 @@
+list: user.code_common_function
+code.language: go
+-
+
+length: len
+append: append
+close: close
+capacity: cap
+clear: clear
+complex: complex
+delete: delete
+imaginary: imag
+max: max
+min: min
+new: new
+panic: panic
+print: print
+print line: println
+real: real
+recover: recover

--- a/lang/go/code-types.talon-list
+++ b/lang/go/code-types.talon-list
@@ -1,0 +1,36 @@
+list: user.code_type
+code.language: go
+-
+
+bool: bool
+boolean: bool
+
+byte: byte
+bite: byte
+
+complex sixty four: complex64
+complex six four: complex64
+complex one twenty eight: complex128
+complex one two eight: complex128
+
+number: int
+integer: int
+int: int
+integer eight: int8
+integer sixteen: int16
+integer thirty two: int32
+integer sixty four: int64
+
+float: float64
+float thirty two: float32
+float sixty four: float64
+
+character: rune
+rune: rune
+
+string: string
+
+machine word: uintptr
+raw pointer: uintptr
+
+comparable: comparable

--- a/lang/go/go.py
+++ b/lang/go/go.py
@@ -1,0 +1,215 @@
+from talon import Context, Module, actions
+
+mod = Module()
+ctx = Context()
+ctx.matches = r"""
+code.language: go
+"""
+
+
+ctx.lists["user.code_type"] = {}
+
+
+def base_function(text: str, visibility: str):
+    """Inserts a public function definition, this assumes a lot about how your editor works"""
+    result = "func {}() {{\n\n}}".format(
+        actions.user.formatted_text(
+            text, visibility
+        )
+    )
+
+    actions.user.insert_between(f"func {text}() {{\n", "")
+
+
+@ctx.action_class("user")
+class UserActions:
+    def code_insert_true():
+        actions.auto_insert(" true ")
+
+    def code_insert_false():
+        actions.auto_insert(" false ")
+
+    def code_insert_null():
+        actions.auto_insert(" nil ")
+
+    def code_insert_is_null():
+        actions.auto_insert(" == nil ")
+
+    def code_insert_is_not_null():
+        actions.auto_insert(" != nil ")
+
+    def code_comment_documentation():
+        """inserts godoc syntax"""
+        actions.key("up")
+        actions.auto_insert("// ")
+
+    def code_default_function(text: str):
+        if text == "main" or text == "mane":
+            actions.user.code_private_function("main")
+        else:
+            actions.user.code_public_function(text)
+
+    def code_public_function(text: str):
+        base_function(text, "PUBLIC_CAMEL_CASE")
+
+    def code_private_function(text: str):
+        base_function(text, "PRIVATE_CAMEL_CASE")
+
+    def code_insert_function(text: str, selection: str):
+        actions.insert(text)
+        actions.insert("()")
+        actions.key("left")
+        actions.insert(selection)
+
+    def code_block():
+        actions.user.insert_between("{\n", "")
+
+    def code_state_if():
+        actions.user.insert_between(" if ", " {")
+
+    def code_state_else_if():
+        actions.user.insert_between(" else if ", " {")
+
+    def code_state_else():
+        actions.insert(" else ")
+        actions.user.code_block()
+
+    def code_state_while():
+        actions.user.code_state_for()
+
+    def code_state_infinite_loop():
+        actions.insert("for ")
+        actions.user.code_block()
+
+    def code_state_for():
+        actions.user.insert_between("for ", " {")
+
+    def code_state_for_each():
+        actions.user.insert_between("for _, ", " := range  {")
+
+    def code_state_switch():
+        actions.user.insert_between("switch ", " {")
+
+    def code_state_case():
+        actions.user.insert_between("case ", ":")
+
+    def code_state_go_to():
+        actions.insert("goto ")
+
+    def code_state_return():
+        actions.insert("return ")
+
+    def code_break():
+        actions.insert("break ")
+
+    def code_next():
+        actions.insert("continue")
+
+    def code_import():
+        actions.user.insert_between("import (", ")")
+        actions.insert("\n")
+
+    def code_operator_subscript():
+        actions.user.insert_between("[", "]")
+
+    def code_operator_assignment():
+        actions.auto_insert(" = ")
+
+    def code_operator_subtraction_assignment():
+        actions.auto_insert(" -= ")
+
+    def code_operator_addition_assignment():
+        actions.auto_insert(" += ")
+
+    def code_operator_multiplication_assignment():
+        actions.auto_insert(" *= ")
+
+    def code_operator_division_assignment():
+        actions.auto_insert(" /= ")
+
+    def code_operator_modulo_assignment():
+        actions.auto_insert(" %= ")
+
+    def code_operator_increment():        
+        actions.auto_insert(" ++ ")
+
+    def code_operator_bitwise_and_assignment():
+        actions.auto_insert(" &= ")
+
+    def code_operator_bitwise_or_assignment():
+        actions.auto_insert(" |= ")
+
+    def code_operator_bitwise_exclusive_or_assignment():
+        actions.auto_insert(" ^= ")
+
+    def code_operator_bitwise_left_shift_assignment():
+        actions.auto_insert(" <<= ")
+
+    def code_operator_bitwise_right_shift_assignment():
+        actions.auto_insert(" >>= ")
+
+    def code_operator_bitwise_and():
+        actions.auto_insert(" & ")
+
+    def code_operator_bitwise_or():
+        actions.auto_insert(" | ")
+
+    def code_operator_bitwise_exclusive_or():
+        actions.auto_insert(" ^ ")
+
+    def code_operator_bitwise_left_shift():
+        actions.auto_insert(" << ")
+
+    def code_operator_bitwise_right_shift():
+        actions.auto_insert(" >> ")
+
+    def code_operator_lambda():
+        actions.user.insert_between("func() {", "}")
+
+    def code_operator_subtraction():
+        actions.auto_insert(" - ")
+
+    def code_operator_addition():
+        actions.auto_insert(" + ")
+
+    def code_operator_multiplication():
+        actions.auto_insert(" * ")
+
+    def code_operator_division():
+        actions.auto_insert(" / ")
+
+    def code_operator_modulo():
+        actions.auto_insert(" % ")
+
+    def code_operator_equal():
+        actions.auto_insert(" == ")
+
+    def code_operator_not_equal():
+        actions.auto_insert(" != ")
+
+    def code_operator_less_than():
+        actions.auto_insert(" < ")
+
+    def code_operator_greater_than():
+        actions.auto_insert(" > ")
+
+    def code_operator_less_than_or_equal_to():
+        actions.auto_insert(" <= ")
+
+    def code_operator_greater_than_or_equal_to():
+        actions.auto_insert(" >= ")
+
+    def code_operator_and():
+        actions.auto_insert(" && ")
+    
+    def code_operator_or():
+        actions.auto_insert(" || ")
+
+    def code_operator_indirection():
+        actions.auto_insert("*")
+
+    def code_operator_address_of():
+        actions.auto_insert("&")
+
+    def code_operator_structure_dereference():
+        actions.auto_insert(".")

--- a/lang/go/go.talon
+++ b/lang/go/go.talon
@@ -1,195 +1,37 @@
 code.language: go
 -
-variadic: "..."
-logical and: " && "
-logical or: " || "
-# Many of these add extra terrible spacing under the assumption that
-# gofmt/goimports will erase it.
-state comment: "// "
-[line] comment <user.text>:
-    key("cmd-right")
-    insert(" // ")
-    insert(user.formatted_text(text, "sentence"))
 
-# "add comment <user.text> [over]:
-#     key("cmd-right")
-#     text_with_leading(" // ")
-# ]
-# "[state] context: insert("ctx")
-state (funk | func | fun): "func "
-function (Annette | init) [over]: "func init() {\n"
-function <user.text> [over]:
-    insert("func ")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-    insert("(")
-    sleep(100ms)
+tag(): user.code_comment_block_c_like
+tag(): user.code_comment_documentation
 
-method <user.text> [over]:
-    insert("meth ")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-    sleep(100ms)
+tag(): user.code_data_bool
+tag(): user.code_data_null
 
-state var: "var "
-variable [<user.text>] [over]:
-    insert("var ")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-    # insert(" ")
-    sleep(100ms)
+tag(): user.code_functions
+tag(): user.code_functions_common
+tag(): user.code_imperative
+tag(): user.code_libraries
 
-of type [<user.text>] [over]:
-    insert(" ")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
+tag(): user.code_operators_array
+tag(): user.code_operators_assignment
+tag(): user.code_operators_bitwise
+tag(): user.code_operators_lambda
+tag(): user.code_operators_math
+tag(): user.code_operators_pointer
 
-# "set <user.text> [over]:
-#     insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-#     insert(" := ")
-#     sleep(100ms)
-# ]
-state break: "break"
-state (chan | channel): " chan "
-state go: "go "
-state if: "if "
-if <user.text> [over]:
-    insert("if ")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-spawn <user.text> [over]:
-    insert("go ")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-state else if: " else if "
-else if <user.text> [over]:
-    insert(" else if ")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
+settings:
+    user.code_private_function_formatter = "PRIVATE_CAMEL_CASE"
+    user.code_protected_function_formatter = "PUBLIC_CAMEL_CASE"
+    user.code_public_function_formatter = "PUBLIC_CAMEL_CASE"
+    user.code_private_variable_formatter = "PRIVATE_CAMEL_CASE"
+    user.code_protected_variable_formatter = "PUBLIC_CAMEL_CASE"
+    user.code_public_variable_formatter = "PUBLIC_CAMEL_CASE"
 
-state else: " else "
-else <user.text> [over]:
-    insert(" else {")
-    key("enter")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
+(main|mane) function: user.code_private_function("main")
 
-state while: "while "
-while <user.text> [over]:
-    insert("while ")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-
-state for: "for "
-for <user.text> [over]:
-    insert("for ")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-
-state for range: "forr "
-range <user.text> [over]:
-    insert("forr ")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-
-state format: "fmt"
-format <user.text> [over]:
-    insert("fmt.")
-    insert(user.formatted_text(text, "PUBLIC_CAMEL_CASE"))
-
-state switch: "switch "
-switch <user.text> [over]:
-    insert("switch ")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-
-state select: "select "
-# "select <user.text>:insert("select "), insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE")]
-state (const | constant): " const "
-constant <user.text> [over]:
-    insert("const ")
-    insert(user.formatted_text(text, "PUBLIC_CAMEL_CASE"))
-
-state case: " case "
-state default: " default:"
-case <user.text> [over]:
-    insert("case ")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-
-state type: " type "
-type <user.text> [over]:
-    insert("type ")
-    insert(user.formatted_text(text, "PUBLIC_CAMEL_CASE"))
-state true: " true "
-state false: " false "
-state (start | struct | struck):
-    insert(" struct {")
-    key("enter")
-(struct | struck) <user.text> [over]:
-    insert(" struct {")
-    key("enter")
-    insert(user.formatted_text(text, "PUBLIC_CAMEL_CASE"))
-
-[state] empty interface: " interface{} "
-state interface:
-    insert(" interface {")
-    key("enter")
-interface <user.text> [over]:
-    insert(" interface {")
-    key("enter")
-    insert(user.formatted_text(text, "PUBLIC_CAMEL_CASE"))
-
-state string: " string "
-[state] (int | integer | ant): "int"
-state slice: " []"
-slice of: "[]"
-[state] (no | nil): "nil"
-state (int | integer | ant) sixty four: " int64 "
-state tag: user.insert_between(" `", "`")
-field tag <user.text> [over]:
-    user.insert_between(" `", "`")
-    sleep(100ms)
-    insert(user.formatted_text(text, "snake"))
-    insert(" ")
-    sleep(100ms)
-
-state return: " return "
-return <user.text> [over]:
-    insert("return ")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-
-map of string to string: " map[string]string "
-map of <user.text> [over]:
-    insert("map[")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-    key("right")
-    sleep(100ms)
-
-receive: " <- "
-make: "make("
-loggers [<user.text>] [over]:
-    insert("logrus.")
-    insert(user.formatted_text(text, "PUBLIC_CAMEL_CASE"))
-
-length <user.text> [over]:
-    insert("len(")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-
-append <user.text> [over]:
-    insert("append(")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
+[state] context: " ctx "
+[state] context (are you|argue): " ctx context.Context "
+state any: " any "
 
 state (air | err): "err"
 error: " err "
-loop over [<user.text>] [over]:
-    insert("forr ")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-
-item <user.text> [over]:
-    insert(", ")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-
-value <user.text> [over]:
-    insert(": ")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-
-address of [<user.text>] [over]:
-    insert("&")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-
-pointer to [<user.text>] [over]:
-    insert("*")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))
-
-swipe [<user.text>] [over]:
-    key("right")
-    insert(", ")
-    insert(user.formatted_text(text, "PRIVATE_CAMEL_CASE"))


### PR DESCRIPTION
The former Go bindings do have some useful things, but overall they create invalid syntax more than they should (never). This brave new syntax binding set will do this a lot better.

Replaces #1308