### PR TITLE
Fix save all keyboard shortcut on the Mac

### DIFF
--- a/core/edit/edit_mac.py
+++ b/core/edit/edit_mac.py
@@ -156,7 +156,7 @@ class EditActions:
         actions.key("cmd-s")
 
     def save_all():
-        actions.key("cmd-shift-s")
+        actions.key("cmd-alt-s")
 
     def select_all():
         actions.key("cmd-a")


### PR DESCRIPTION
`cmd-shift-s` is typically reserved for `Duplicate` or `Save As…` on the Mac. Save all, where it exists, is typically `cmd-alt-s`.