### PR TITLE
add code_insert_if_let_okay to rust Actions module

### DIFF
--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -20,6 +20,9 @@ class Actions:
     def code_insert_if_let_error():
         """Inserts if let error block, positioning the cursor appropriately"""
 
+    def code_insert_if_let_okay():
+        """Inserts if let okay block, positioning the cursor appropriately"""
+
     def code_insert_trait_annotation(type: str):
         """Inserts type annotation for implementor of trait"""
 


### PR DESCRIPTION
without this, if you are in rust language mode, you will get a bunch of `WARNING actions: skipped because they have no matching declaration: (user.code_insert_if_let_okay)` (from rust.talon) and some other talon stuff won't work