### PR TITLE
lang: imperative: Remove unused code_state_continue action

### DIFF
--- a/lang/tags/imperative.py
+++ b/lang/tags/imperative.py
@@ -53,11 +53,8 @@ class Actions:
     def code_break():
         """Inserts break statement"""
 
-    def code_state_continue():
-        """Inserts continue statement"""
-
     def code_next():
-        """Inserts next statement"""
+        """Inserts next/continue statement"""
 
     def code_try_catch():
         """Inserts try/catch. If selection is true, does so around the selection"""


### PR DESCRIPTION
No language implements this, and there's no voice command for this action either.