### PR TITLE
lang: Add tag for brace-delimited code blocks

### DIFF
--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -2,6 +2,7 @@ code.language: c
 -
 tag(): user.code_imperative
 
+tag(): user.code_block_c_like
 tag(): user.code_comment_line
 tag(): user.code_comment_block_c_like
 tag(): user.code_data_bool

--- a/lang/csharp/csharp.py
+++ b/lang/csharp/csharp.py
@@ -116,10 +116,6 @@ class UserActions:
     def code_operator_bitwise_right_shift_assignment():
         actions.auto_insert(" >>= ")
 
-    def code_block():
-        actions.insert("{}")
-        actions.key("left enter enter up tab")
-
     def code_self():
         actions.auto_insert("this")
 

--- a/lang/csharp/csharp.talon
+++ b/lang/csharp/csharp.talon
@@ -3,6 +3,7 @@ code.language: csharp
 tag(): user.code_imperative
 tag(): user.code_object_oriented
 
+tag(): user.code_block_c_like
 tag(): user.code_comment_line
 tag(): user.code_comment_block_c_like
 tag(): user.code_data_bool

--- a/lang/css/css.py
+++ b/lang/css/css.py
@@ -107,10 +107,6 @@ ctx.lists["user.code_common_function"] = {
 
 @ctx.action_class("user")
 class UserActions:
-    def code_block():
-        actions.user.insert_between("{", "}")
-        actions.key("enter")
-
     def code_operator_addition():
         actions.insert(" + ")
 

--- a/lang/css/css.talon
+++ b/lang/css/css.talon
@@ -1,6 +1,7 @@
 code.language: css
 code.language: scss
 -
+tag(): user.code_block_c_like
 tag(): user.code_comment_block_c_like
 tag(): user.code_functions_common
 tag(): user.code_libraries

--- a/lang/java/java.talon
+++ b/lang/java/java.talon
@@ -3,6 +3,7 @@ code.language: java
 tag(): user.code_imperative
 tag(): user.code_object_oriented
 
+tag(): user.code_block_c_like
 tag(): user.code_comment_line
 tag(): user.code_comment_block_c_like
 tag(): user.code_data_bool

--- a/lang/javascript/javascript.py
+++ b/lang/javascript/javascript.py
@@ -92,10 +92,6 @@ class UserActions:
         actions.user.insert_between(" else {", "}")
         actions.key("enter")
 
-    def code_block():
-        actions.user.insert_between("{", "}")
-        actions.key("enter")
-
     def code_self():
         actions.auto_insert("this")
 

--- a/lang/javascript/javascript.talon
+++ b/lang/javascript/javascript.talon
@@ -6,6 +6,7 @@ code.language: typescriptreact
 tag(): user.code_imperative
 tag(): user.code_object_oriented
 
+tag(): user.code_block_c_like
 tag(): user.code_comment_line
 tag(): user.code_comment_block_c_like
 tag(): user.code_data_bool

--- a/lang/php/php.py
+++ b/lang/php/php.py
@@ -27,11 +27,6 @@ class UserActions:
     def code_define_class():
         actions.auto_insert("class ")
 
-    def code_block():
-        actions.insert("{}")
-        actions.edit.left()
-        actions.key("enter")
-
     def code_import():
         actions.auto_insert("use ;")
         actions.edit.left()

--- a/lang/php/php.talon
+++ b/lang/php/php.talon
@@ -4,6 +4,7 @@ tag(): user.code_imperative
 tag(): user.code_object_oriented
 tag(): user.code_libraries
 
+tag(): user.code_block_c_like
 tag(): user.code_comment_line
 tag(): user.code_comment_block
 tag(): user.code_comment_documentation

--- a/lang/proto/proto.talon
+++ b/lang/proto/proto.talon
@@ -1,7 +1,10 @@
 code.language: protobuf
 -
+tag(): user.code_block_c_like
 
 # this is pretty bare-bones, further contributions welcome
+block: user.code_block()
+
 state message: "message "
 state package: "package "
 state reserved: "reserved "

--- a/lang/r/r.talon
+++ b/lang/r/r.talon
@@ -2,6 +2,7 @@ code.language: r
 -
 tag(): user.code_imperative
 
+tag(): user.code_block_c_like
 tag(): user.code_comment_line
 tag(): user.code_data_bool
 tag(): user.code_data_null

--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -248,11 +248,6 @@ class UserActions:
 
     # tag: imperative
 
-    def code_block():
-        actions.auto_insert("{}")
-        actions.edit.left()
-        actions.key("enter")
-
     def code_state_if():
         actions.auto_insert("if ")
 

--- a/lang/rust/rust.talon
+++ b/lang/rust/rust.talon
@@ -4,6 +4,7 @@ tag(): user.code_comment_line
 tag(): user.code_comment_block_c_like
 tag(): user.code_comment_documentation
 
+tag(): user.code_block_c_like
 tag(): user.code_imperative
 tag(): user.code_object_oriented
 

--- a/lang/scala/scala.py
+++ b/lang/scala/scala.py
@@ -86,11 +86,6 @@ ctx.lists["user.scala_keyword"] = scala_keywords
 
 @ctx.action_class("user")
 class UserActions:
-    def code_block():
-        actions.insert("{}")
-        actions.edit.left()
-        actions.key("enter")
-
     def code_operator_lambda():
         actions.insert(" => ")
 

--- a/lang/scala/scala.talon
+++ b/lang/scala/scala.talon
@@ -3,6 +3,7 @@ code.language: scala
 tag(): user.code_imperative
 tag(): user.code_object_oriented
 
+tag(): user.code_block_c_like
 tag(): user.code_comment_line
 tag(): user.code_comment_block_c_like
 tag(): user.code_data_bool

--- a/lang/tags/imperative.py
+++ b/lang/tags/imperative.py
@@ -1,12 +1,17 @@
-from talon import Context, Module
+from talon import Context, Module, actions
 
-ctx = Context()
+c_like_ctx = Context()
 mod = Module()
 
 mod.tag(
     "code_imperative",
     desc="Tag for enabling basic imperative programming commands (loops, functions, etc)",
 )
+mod.tag("code_block_c_like", desc="Language uses C style code blocks, i.e. braces")
+
+c_like_ctx.matches = """
+tag: self.code_block_c_like
+"""
 
 
 @mod.action_class
@@ -61,3 +66,10 @@ class Actions:
 
     def code_try_catch():
         """Inserts try/catch. If selection is true, does so around the selection"""
+
+
+@c_like_ctx.action_class("self")
+class CActions:
+    def code_block():
+        actions.user.insert_between("{", "}")
+        actions.key("enter")

--- a/lang/terraform/terraform.talon
+++ b/lang/terraform/terraform.talon
@@ -1,5 +1,6 @@
 code.language: terraform
 -
+tag(): user.code_block_c_like
 tag(): user.code_comment_block_c_like
 tag(): user.code_comment_line
 tag(): user.code_data_bool
@@ -8,6 +9,8 @@ tag(): user.code_imperative
 tag(): user.code_operators_assignment
 tag(): user.code_operators_lambda
 tag(): user.code_operators_math
+
+block: user.code_block()
 
 state {user.terraform_module_block}:
     user.code_terraform_module_block(user.terraform_module_block)


### PR DESCRIPTION
## Problem

Several languages had the same, or similar, copy-pasted implementations of `code_block` to insert braces and leave the cursor on a blank line between them. These all assume the editor will appropriately expand <kbd>enter</kbd> between brackets, which isn't true for all editors.

The C# implementation implemented the same idea, but appears to assume <kbd>enter</kbd> _isn't_ expanded.

Furthermore, some C-like languages were missing a `code_block` impl entirely.

## Solution

Similar to #720, this adds a common implementation for braced code blocks, which can be overridden on a per-editor basis, and adds the tag to the appropriate languages.