### PR TITLE
Add recommended snip shortcuts

### DIFF
--- a/apps/vscode/vscode.talon
+++ b/apps/vscode/vscode.talon
@@ -55,8 +55,8 @@ show shortcuts json: user.vscode("workbench.action.openGlobalKeybindingsFile")
 show snippets: user.vscode("workbench.action.openSnippets")
 
 # VSCode Snippets
-snip last:                  user.vscode("jumpToPrevSnippetPlaceholder")
-[snip] next:                user.vscode("jumpToNextSnippetPlaceholder")
+snip last: user.vscode("jumpToPrevSnippetPlaceholder")
+[snip] next: user.vscode("jumpToNextSnippetPlaceholder")
 
 # Display
 centered switch: user.vscode("workbench.action.toggleCenteredLayout")

--- a/apps/vscode/vscode.talon
+++ b/apps/vscode/vscode.talon
@@ -55,7 +55,7 @@ show shortcuts json: user.vscode("workbench.action.openGlobalKeybindingsFile")
 show snippets: user.vscode("workbench.action.openSnippets")
 
 # VSCode Snippets
-snip (last|previous): user.vscode("jumpToPrevSnippetPlaceholder")
+snip (last | previous): user.vscode("jumpToPrevSnippetPlaceholder")
 snip next: user.vscode("jumpToNextSnippetPlaceholder")
 
 # Display

--- a/apps/vscode/vscode.talon
+++ b/apps/vscode/vscode.talon
@@ -56,6 +56,7 @@ show snippets: user.vscode("workbench.action.openSnippets")
 
 # VSCode Snippets
 snip last: user.vscode("jumpToPrevSnippetPlaceholder")
+snip previous: user.vscode("jumpToPrevSnippetPlaceholder")
 snip next: user.vscode("jumpToNextSnippetPlaceholder")
 
 # Display

--- a/apps/vscode/vscode.talon
+++ b/apps/vscode/vscode.talon
@@ -55,8 +55,7 @@ show shortcuts json: user.vscode("workbench.action.openGlobalKeybindingsFile")
 show snippets: user.vscode("workbench.action.openSnippets")
 
 # VSCode Snippets
-snip last: user.vscode("jumpToPrevSnippetPlaceholder")
-snip previous: user.vscode("jumpToPrevSnippetPlaceholder")
+snip (last|previous): user.vscode("jumpToPrevSnippetPlaceholder")
 snip next: user.vscode("jumpToNextSnippetPlaceholder")
 
 # Display

--- a/apps/vscode/vscode.talon
+++ b/apps/vscode/vscode.talon
@@ -56,7 +56,7 @@ show snippets: user.vscode("workbench.action.openSnippets")
 
 # VSCode Snippets
 snip last: user.vscode("jumpToPrevSnippetPlaceholder")
-[snip] next: user.vscode("jumpToNextSnippetPlaceholder")
+snip next: user.vscode("jumpToNextSnippetPlaceholder")
 
 # Display
 centered switch: user.vscode("workbench.action.toggleCenteredLayout")

--- a/apps/vscode/vscode.talon
+++ b/apps/vscode/vscode.talon
@@ -54,6 +54,10 @@ show shortcuts: user.vscode("workbench.action.openGlobalKeybindings")
 show shortcuts json: user.vscode("workbench.action.openGlobalKeybindingsFile")
 show snippets: user.vscode("workbench.action.openSnippets")
 
+# VSCode Snippets
+snip last:                  user.vscode("jumpToPrevSnippetPlaceholder")
+[snip] next:                user.vscode("jumpToNextSnippetPlaceholder")
+
 # Display
 centered switch: user.vscode("workbench.action.toggleCenteredLayout")
 fullscreen switch: user.vscode("workbench.action.toggleFullScreen")


### PR DESCRIPTION
- These shortcuts are unambiguous for navigating snippets in VSCode

Thanks to @AndreasArvidsson for [the example](https://github.com/AndreasArvidsson/andreas-talon/blob/59cfecd26c3a01e72847364f6cafb5cdb8202b1b/apps/vscode/vscode.talon#L239)