### PR TITLE
rust: Inline Rust-specific one-line actions

### DIFF
--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -14,18 +14,6 @@ class Actions:
     def code_state_implements():
         """Inserts implements block, positioning the cursor appropriately"""
 
-    def code_insert_if_let_some():
-        """Inserts if let some block, positioning the cursor appropriately"""
-
-    def code_insert_if_let_error():
-        """Inserts if let error block, positioning the cursor appropriately"""
-
-    def code_insert_trait_annotation(type: str):
-        """Inserts type annotation for implementor of trait"""
-
-    def code_insert_return_trait(type: str):
-        """Inserts a return type for implementor of trait"""
-
     def code_insert_macro(text: str, selection: str):
         """Inserts a macro and positions the cursor appropriately"""
 
@@ -479,15 +467,6 @@ class UserActions:
     def code_operator_structure_dereference():
         actions.auto_insert("*")
 
-    def code_insert_if_let_some():
-        actions.user.insert_between("if let Some(", ")")
-
-    def code_insert_if_let_okay():
-        actions.user.insert_between("if let Ok(", ")")
-
-    def code_insert_if_let_error():
-        actions.user.insert_between("if let Err(", ")")
-
     def code_state_implements():
         actions.auto_insert("impl  {}")
         actions.edit.left()
@@ -495,12 +474,6 @@ class UserActions:
         actions.edit.up()
         actions.edit.line_end()
         repeat_call(2, actions.edit.left)
-
-    def code_insert_trait_annotation(type: str):
-        actions.auto_insert(f": impl {type}")
-
-    def code_insert_return_trait(type: str):
-        actions.auto_insert(f" -> impl {type}")
 
     def code_insert_macro(text: str, selection: str):
         if text in all_array_macro_values:

--- a/lang/rust/rust.talon
+++ b/lang/rust/rust.talon
@@ -73,9 +73,9 @@ use <user.code_libraries>:
     key(; enter)
 
 ## specialist flow control
-state if let some: user.code_insert_if_let_some()
-state if let (ok | okay): user.code_insert_if_let_okay()
-state if let error: user.code_insert_if_let_error()
+state if let some: user.insert_between("if let Some(", ")")
+state if let (ok | okay): user.insert_between("if let Ok(", ")")
+state if let error: user.insert_between("if let Err(", ")")
 
 ## rust centric synonyms
 is some: user.code_insert_is_not_null()
@@ -84,9 +84,9 @@ is some: user.code_insert_is_not_null()
 implement (struct | structure): user.code_state_implements()
 
 ## for annotating function parameters
-is implemented trait {user.code_trait}: user.code_insert_trait_annotation(code_trait)
+is implemented trait {user.code_trait}: ": impl {code_trait}"
 is implemented trait: ": impl "
-returns implemented trait {user.code_trait}: user.code_insert_return_trait(code_trait)
+returns implemented trait {user.code_trait}: " -> impl {code_trait}"
 returns implemented trait: " -> impl "
 
 ## for generic reference of traits


### PR DESCRIPTION
These realistically have no business being actions:

- They're only used in one place.
- They're extremely simple, as they're only one line.
- There is no use-case for overriding them.

This inlines the actions into the Talonscript.

Closes: #1323