### PR TITLE
Update jetbrains.py to include rider for mac

### DIFF
--- a/apps/jetbrains/jetbrains.py
+++ b/apps/jetbrains/jetbrains.py
@@ -134,6 +134,8 @@ mod.apps.jetbrains = "app.exe: webstorm64.exe"
 mod.apps.jetbrains = """
 os: mac
 and app.bundle: com.jetbrains.pycharm
+os: mac
+and app.bundle: com.jetbrains.rider
 """
 mod.apps.jetbrains = """
 os: windows


### PR DESCRIPTION
Now jetbrains rider works correctly like the other jetbrains products