### PR TITLE
configurable number prefix without mouse grid

### DIFF
--- a/BREAKING_CHANGES.txt
+++ b/BREAKING_CHANGES.txt
@@ -6,7 +6,11 @@ applied given the delay between changes being submitted and the time they were r
 and merged.
 
 ---
-* 2023-06-06 Deprecate `go marks` command for VSCode. Use 'bar marks' instead.
+* 2024-01-27 Deprecate '<user.number_string>' command without a spoken prefix like `numb`.
+See `numbers.talon` and `numbers_unprefixed.talon.` If in the future you want to still use
+unprefixed numbers, you will need to comment out the
+`tag(): user.disable_unprefixed_numbers` line in your `settings.talon` file.
+* 2023-06-06 Deprecate `go ` command for VSCode. Use 'bar marks' instead.
 * 2023-02-04 Deprecate `murder` command for i3wm. Use 'win kill' instead.
 * 2022-12-11 Deprecate user.insert_with_history. Just use `user.add_phrase_to_history(text);
 insert(text)` instead. See #939.

--- a/BREAKING_CHANGES.txt
+++ b/BREAKING_CHANGES.txt
@@ -9,7 +9,7 @@ and merged.
 * 2024-01-27 Deprecate '<user.number_string>' command without a spoken prefix like `numb`.
 See `numbers.talon` and `numbers_unprefixed.talon.` If in the future you want to still use
 unprefixed numbers, you will need to comment out the
-`tag(): user.disable_unprefixed_numbers` line in your `settings.talon` file.
+`tag(): user.prefixed_numbers` line in your `settings.talon` file.
 * 2023-06-06 Deprecate `go ` command for VSCode. Use 'bar marks' instead.
 * 2023-02-04 Deprecate `murder` command for i3wm. Use 'win kill' instead.
 * 2022-12-11 Deprecate user.insert_with_history. Just use `user.add_phrase_to_history(text);

--- a/core/mouse_grid/mouse_grid_open.talon
+++ b/core/mouse_grid/mouse_grid_open.talon
@@ -1,5 +1,6 @@
 tag: user.mouse_grid_showing
 -
+tag(): user.disable_unprefixed_numbers
 <user.number_key>: user.grid_narrow(number_key)
 grid off: user.grid_close()
 

--- a/core/mouse_grid/mouse_grid_open.talon
+++ b/core/mouse_grid/mouse_grid_open.talon
@@ -1,6 +1,7 @@
 tag: user.mouse_grid_showing
 -
-tag(): user.disable_unprefixed_numbers
+# Force prefixed numbers elsewhere in the config, which allows unprefixed use below
+tag(): user.prefixed_numbers
 <user.number_key>: user.grid_narrow(number_key)
 grid off: user.grid_close()
 

--- a/core/numbers/numbers.py
+++ b/core/numbers/numbers.py
@@ -177,6 +177,7 @@ for ten in tens:
 number_small_map = {n: i for i, n in enumerate(number_small_list)}
 
 mod.list("number_small", desc="List of small numbers")
+mod.tag("require_numb_prefix", desc="require number prefix when saying a number")
 ctx.lists["self.number_small"] = number_small_map.keys()
 
 

--- a/core/numbers/numbers.py
+++ b/core/numbers/numbers.py
@@ -177,7 +177,7 @@ for ten in tens:
 number_small_map = {n: i for i, n in enumerate(number_small_list)}
 
 mod.list("number_small", desc="List of small numbers")
-mod.tag("disable_unprefixed_numbers", desc="Require prefix when saying a number")
+mod.tag("prefixed_numbers", desc="Require prefix when saying a number")
 ctx.lists["self.number_small"] = number_small_map.keys()
 
 

--- a/core/numbers/numbers.py
+++ b/core/numbers/numbers.py
@@ -177,7 +177,7 @@ for ten in tens:
 number_small_map = {n: i for i, n in enumerate(number_small_list)}
 
 mod.list("number_small", desc="List of small numbers")
-mod.tag("require_numb_prefix", desc="require number prefix when saying a number")
+mod.tag("disable_unprefixed_numbers", desc="Require prefix when saying a number")
 ctx.lists["self.number_small"] = number_small_map.keys()
 
 

--- a/core/numbers/numbers.talon
+++ b/core/numbers/numbers.talon
@@ -1,4 +1,4 @@
 not tag: user.mouse_grid_showing
-not tag: user.require_numb_prefix
+and not tag: user.require_numb_prefix
 -
 <user.number_string>: "{number_string}"

--- a/core/numbers/numbers.talon
+++ b/core/numbers/numbers.talon
@@ -1,3 +1,1 @@
-not tag: user.require_numb_prefix
--
-<user.number_string>: "{number_string}"
+numb <user.number_string>: "{number_string}"

--- a/core/numbers/numbers.talon
+++ b/core/numbers/numbers.talon
@@ -1,3 +1,4 @@
 not tag: user.mouse_grid_showing
+not tag: user.require_numb_prefix
 -
 <user.number_string>: "{number_string}"

--- a/core/numbers/numbers.talon
+++ b/core/numbers/numbers.talon
@@ -1,4 +1,3 @@
-not tag: user.mouse_grid_showing
-and not tag: user.require_numb_prefix
+not tag: user.require_numb_prefix
 -
 <user.number_string>: "{number_string}"

--- a/core/numbers/numbers_unprefixed.talon
+++ b/core/numbers/numbers_unprefixed.talon
@@ -1,3 +1,5 @@
 not tag: user.disable_unprefixed_numbers
 -
-<user.number_string>: "{number_string}"
+<user.number_string>:
+    insert("{number_string}")
+    user.deprecate_command("2024-01-27", "unprefixed <user.number_string>", "prefixed <user.number_string>")

--- a/core/numbers/numbers_unprefixed.talon
+++ b/core/numbers/numbers_unprefixed.talon
@@ -1,4 +1,4 @@
-not tag: user.disable_unprefixed_numbers
+not tag: user.prefixed_numbers
 -
 <user.number_string>:
     insert("{number_string}")

--- a/core/numbers/numbers_unprefixed.talon
+++ b/core/numbers/numbers_unprefixed.talon
@@ -1,0 +1,3 @@
+not tag: user.disable_unprefixed_numbers
+-
+<user.number_string>: "{number_string}"

--- a/core/numbers/numbers_unprefixed.talon
+++ b/core/numbers/numbers_unprefixed.talon
@@ -2,4 +2,4 @@ not tag: user.prefixed_numbers
 -
 <user.number_string>:
     insert("{number_string}")
-    user.deprecate_command("2024-01-27", "unprefixed <user.number_string>", "prefixed <user.number_string>")
+    user.deprecate_command("2024-01-27", "<number>", "numb <number>")

--- a/core/numbers/numbers_with_prefix.talon
+++ b/core/numbers/numbers_with_prefix.talon
@@ -1,4 +1,3 @@
-not tag: user.mouse_grid_showing
-and tag: user.require_numb_prefix
+tag: user.require_numb_prefix
 -
 numb <user.number_string>: "{number_string}"

--- a/core/numbers/numbers_with_prefix.talon
+++ b/core/numbers/numbers_with_prefix.talon
@@ -1,3 +1,0 @@
-tag: user.require_numb_prefix
--
-numb <user.number_string>: "{number_string}"

--- a/core/numbers/numbers_with_prefix.talon
+++ b/core/numbers/numbers_with_prefix.talon
@@ -1,0 +1,4 @@
+not tag: user.mouse_grid_showing
+tag: user.require_numb_prefix
+-
+numb <user.number_string>: "{number_string}"

--- a/core/numbers/numbers_with_prefix.talon
+++ b/core/numbers/numbers_with_prefix.talon
@@ -1,4 +1,4 @@
 not tag: user.mouse_grid_showing
-tag: user.require_numb_prefix
+and tag: user.require_numb_prefix
 -
 numb <user.number_string>: "{number_string}"

--- a/settings.talon
+++ b/settings.talon
@@ -76,4 +76,4 @@ settings():
 # By default saying "one" would write "1", however many users find this behavior
 # prone to false positives. If you uncomment this, you will need to say
 # "numb one" to write "1".
-# tag(): user.disable_unprefixed_numbers
+# tag(): user.prefixed_numbers

--- a/settings.talon
+++ b/settings.talon
@@ -69,11 +69,11 @@ settings():
     # -width windows are resized to stay full-height/width.
     #user.window_snap_screen = "size aware"
 
-    # Uncomment the below to disable support for saying numbers without a prefix.
-    # By default saying "one" would write "1", however many users find this behavior
-    # prone to false positives. If you uncomment this, you will need to say
-    # "numb one" to write "1".
-    #user.disable_unprefixed_numbers = 1
-
 # Uncomment this to enable the curse yes/curse no commands (show hide mouse cursor). See issue #688.
 # tag(): user.mouse_cursor_commands_enable
+
+# Uncomment the below to disable support for saying numbers without a prefix.
+# By default saying "one" would write "1", however many users find this behavior
+# prone to false positives. If you uncomment this, you will need to say
+# "numb one" to write "1".
+# tag(): user.disable_unprefixed_numbers

--- a/settings.talon
+++ b/settings.talon
@@ -69,5 +69,11 @@ settings():
     # -width windows are resized to stay full-height/width.
     #user.window_snap_screen = "size aware"
 
+    # Uncomment the below to disable support for saying numbers without a prefix.
+    # By default saying "one" would write "1", however many users find this behavior
+    # prone to false positives. If you uncomment this, you will need to say
+    # "numb one" to write "1".
+    #user.disable_unprefixed_numbers = 1
+
 # Uncomment this to enable the curse yes/curse no commands (show hide mouse cursor). See issue #688.
 # tag(): user.mouse_cursor_commands_enable

--- a/settings.talon
+++ b/settings.talon
@@ -75,5 +75,5 @@ settings():
 # Uncomment the below to disable support for saying numbers without a prefix.
 # By default saying "one" would write "1", however many users find this behavior
 # prone to false positives. If you uncomment this, you will need to say
-# "numb one" to write "1".
+# "numb one" to write "1". Note that this tag will eventually be activated by default
 # tag(): user.prefixed_numbers


### PR DESCRIPTION
- Attempt to implement optional numb prefix
- The tags need to be logically combined
- Respond to suggestion that the mouse grid should not be considered
