### PR TITLE
allow mouse commands to work in zoom mode

### DIFF
--- a/plugin/mouse/mouse.py
+++ b/plugin/mouse/mouse.py
@@ -109,6 +109,11 @@ def gui_wheel(gui: imgui.GUI):
 
 @mod.action_class
 class Actions:
+    def zoom_close():
+        """Closes an in-progress zoom. Talon will move the cursor position but not click."""
+        if eye_zoom_mouse.zoom_mouse.state == eye_zoom_mouse.STATE_OVERLAY:
+            actions.tracking.zoom_cancel()
+
     def mouse_show_cursor():
         """Shows the cursor"""
         show_cursor_helper(True)

--- a/plugin/mouse/mouse.talon
+++ b/plugin/mouse/mouse.talon
@@ -4,6 +4,8 @@ zoom mouse: tracking.control_zoom_toggle()
 camera overlay: tracking.control_debug_toggle()
 run calibration: tracking.calibrate()
 touch:
+    # close zoom if open
+    user.zoom_close()
     mouse_click(0)
     # close the mouse grid if open
     user.grid_close()
@@ -12,11 +14,15 @@ touch:
     user.mouse_drag_end()
 
 righty:
+    # close zoom if open
+    user.zoom_close()
     mouse_click(1)
     # close the mouse grid if open
     user.grid_close()
 
 mid click:
+    # close zoom if open
+    user.zoom_close()
     mouse_click(2)
     # close the mouse grid
     user.grid_close()
@@ -29,33 +35,45 @@ mid click:
 #shift
 #super = windows key
 <user.modifiers> touch:
+    # close zoom if open
+    user.zoom_close()
     key("{modifiers}:down")
     mouse_click(0)
     key("{modifiers}:up")
     # close the mouse grid
     user.grid_close()
 <user.modifiers> righty:
+    # close zoom if open
+    user.zoom_close()
     key("{modifiers}:down")
     mouse_click(1)
     key("{modifiers}:up")
     # close the mouse grid
     user.grid_close()
 (dub click | duke):
+    # close zoom if open
+    user.zoom_close()
     mouse_click()
     mouse_click()
     # close the mouse grid
     user.grid_close()
 (trip click | trip lick):
+    # close zoom if open
+    user.zoom_close()
     mouse_click()
     mouse_click()
     mouse_click()
     # close the mouse grid
     user.grid_close()
 left drag | drag:
+    # close zoom if open
+    user.zoom_close()
     user.mouse_drag(0)
     # close the mouse grid
     user.grid_close()
 right drag | righty drag:
+    # close zoom if open
+    user.zoom_close()
     user.mouse_drag(1)
     # close the mouse grid
     user.grid_close()


### PR DESCRIPTION
previously they would sporatically work but the zoom overlay window would stay open