### PR TITLE
Add ruby op-or-equals command

### DIFF
--- a/lang/javascript/javascript.py
+++ b/lang/javascript/javascript.py
@@ -188,6 +188,9 @@ class UserActions:
     def code_operator_equal():
         actions.auto_insert(" == ")
 
+    def code_or_operator_assignment():
+        actions.auto_insert(" ||= ")
+
     def code_operator_not_equal():
         actions.auto_insert(" != ")
 

--- a/lang/ruby/ruby.py
+++ b/lang/ruby/ruby.py
@@ -18,6 +18,9 @@ class UserActions:
     def code_operator_assignment():
         actions.auto_insert(" = ")
 
+    def code_or_operator_assignment():
+        actions.auto_insert(" ||= ")
+
     def code_operator_subtraction():
         actions.auto_insert(" - ")
 

--- a/lang/ruby/ruby.talon
+++ b/lang/ruby/ruby.talon
@@ -33,6 +33,7 @@ state begin: "begin"
 state rescue: "rescue "
 state module: "module "
 
+op or equals: auto_insert(" ||= ")
 ^instance <user.text>$:
     insert("@")
     user.code_public_variable_formatter(text)

--- a/lang/ruby/ruby.talon
+++ b/lang/ruby/ruby.talon
@@ -33,7 +33,6 @@ state begin: "begin"
 state rescue: "rescue "
 state module: "module "
 
-op or equals: auto_insert(" ||= ")
 ^instance <user.text>$:
     insert("@")
     user.code_public_variable_formatter(text)

--- a/lang/tags/operators_assignment.py
+++ b/lang/tags/operators_assignment.py
@@ -11,6 +11,9 @@ class Actions:
     def code_operator_assignment():
         """code_operator_assignment"""
 
+    def code_or_operator_assignment():
+        """code_operator_assignment"""
+
     def code_operator_subtraction_assignment():
         """code_operator_subtraction_assignment"""
 

--- a/lang/tags/operators_assignment.talon
+++ b/lang/tags/operators_assignment.talon
@@ -5,6 +5,7 @@ tag(): user.code_operators_bitwise
 
 # assignment
 op (equals | assign): user.code_operator_assignment()
+op or equals: user.code_or_operator_assignment()
 
 # combined computation and assignment
 op (minus | subtract) equals: user.code_operator_subtraction_assignment()


### PR DESCRIPTION
- without this, saying `op or equals` would be interpreted as `op or`
  followed by `equals`, which results in a syntax error `|| =`
