### PR TITLE
Switch markdown code blocks to use snippets

### DIFF
--- a/lang/markdown/markdown.talon
+++ b/lang/markdown/markdown.talon
@@ -39,10 +39,7 @@ list six:
     "                    - "
 
 {user.markdown_code_block_language} block:
-    "```{markdown_code_block_language}"
-    key(enter:2)
-    "```"
-    key(up)
+    user.insert_snippet("```{markdown_code_block_language}\n$0\n```")
 
 link:
     "[]()"


### PR DESCRIPTION
This avoids issues with extra closing backticks in VSCode due to automatic delimiter closing