### PR TITLE
use double quotes for git commit message

### DIFF
--- a/apps/git/git.talon
+++ b/apps/git/git.talon
@@ -7,11 +7,11 @@ git {user.git_command} [<user.git_arguments>]:
 git commit [<user.git_arguments>] message [<user.prose>]:
     args = git_arguments or ""
     message = prose or ""
-    user.insert_between("git commit{args} --message '{message}", "'")
+    user.insert_between("git commit{args} --message \"{message}", "\"")
 git stash [push] [<user.git_arguments>] message [<user.prose>]:
     args = git_arguments or ""
     message = prose or ""
-    user.insert_between("git stash push{args} --message '{message}", "'")
+    user.insert_between("git stash push{args} --message \"{message}", "\"")
 
 # Optimistic execution for frequently used commands that are harmless (don't
 # change repository or index state).

--- a/apps/git/git.talon
+++ b/apps/git/git.talon
@@ -7,11 +7,11 @@ git {user.git_command} [<user.git_arguments>]:
 git commit [<user.git_arguments>] message [<user.prose>]:
     args = git_arguments or ""
     message = prose or ""
-    user.insert_between("git commit{args} --message \"{message}", "\"")
+    user.insert_between('git commit{args} --message "{message}', '"')
 git stash [push] [<user.git_arguments>] message [<user.prose>]:
     args = git_arguments or ""
     message = prose or ""
-    user.insert_between("git stash push{args} --message \"{message}", "\"")
+    user.insert_between('git stash push{args} --message "{message}', '"')
 
 # Optimistic execution for frequently used commands that are harmless (don't
 # change repository or index state).


### PR DESCRIPTION
Double quotes allow you to use contractions (don't, isn't, etc) in the commit message without having to escape them. On the other hand they mean that some special characters need escaping. I find that double quotes are a better default for me. If other folks disagree, feel free to nix this PR. 