### PR TITLE
mouse grid: add method to test if mouse grid is active.

### DIFF
--- a/core/mouse_grid/mouse_grid.py
+++ b/core/mouse_grid/mouse_grid.py
@@ -307,3 +307,7 @@ class GridActions:
         """Close the active grid"""
         ctx.tags = []
         mg.close()
+
+    def grid_is_active():
+        """check if grid is already active"""
+        return mg.active


### PR DESCRIPTION
I use this as I have commands which want to ensure a consistent moue grid state before and after they have run.
e.g. If the mouse grid was active before the command runs, they leave it active afterwards, if the mouse grid was closed then it is left closed.