### PR TITLE
mouse: adding synonyms for starting left drag.

### DIFF
--- a/plugin/mouse/mouse.talon
+++ b/plugin/mouse/mouse.talon
@@ -65,7 +65,7 @@ mid click:
     mouse_click()
     # close the mouse grid
     user.grid_close()
-left drag | drag:
+left drag | drag | drag start:
     # close zoom if open
     user.zoom_close()
     user.mouse_drag(0)


### PR DESCRIPTION
I would regularly say `drag start` which would cause an asterisk to be inserted.