### PR TITLE
pre-commit: Remove black args

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,6 @@ repos:
     rev: 23.12.1
     hooks:
       - id: black
-        args: ["--target-version", "py310"]
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.4
     hooks:


### PR DESCRIPTION
There should be a single source of truth for Black's config. This makes `pyproject.toml` that source of truth.