### PR TITLE
Convert boolean settings to boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ https://github.com/talonhub/community/blob/main/settings.talon
 #adjust the scale of the imgui to my liking
 imgui.scale = 1.3
 # enable if you'd like the picker gui to automatically appear when explorer has focus
-user.file_manager_auto_show_pickers = 0
+user.file_manager_auto_show_pickers = false
 #set the max number of command lines per page in help
 user.help_max_command_lines_per_page = 50
 # set the max number of contexts display per page in help
@@ -282,13 +282,13 @@ user.help_max_contexts_per_page = 20
 # The default amount used when scrolling continuously
 user.mouse_continuous_scroll_amount = 80
 #stop continuous scroll/gaze scroll with a pop
-user.mouse_enable_pop_stops_scroll = 1
+user.mouse_enable_pop_stops_scroll = true
 #enable pop click with 'control mouse' mode
-user.mouse_enable_pop_click = 1
+user.mouse_enable_pop_click = true
 #When enabled, the 'Scroll Mouse' GUI will not be shown.
-user.mouse_hide_mouse_gui = 0
+user.mouse_hide_mouse_gui = false
 #hide cursor when mouse_wake is called to enable zoom mouse
-user.mouse_wake_hides_cursor = 0
+user.mouse_wake_hides_cursor = false
 #the amount to scroll up/down (equivalent to mouse wheel on Windows by default)
 user.mouse_wheel_down_amount = 120
 ```

--- a/core/modes/sleep_mode.talon
+++ b/core/modes/sleep_mode.talon
@@ -2,11 +2,11 @@ mode: sleep
 -
 settings():
     # Stop continuous scroll/gaze scroll with a pop
-    user.mouse_enable_pop_stops_scroll = 0
+    user.mouse_enable_pop_stops_scroll = false
     # Enable pop click with 'control mouse' mode
-    user.mouse_enable_pop_click = 0
+    user.mouse_enable_pop_click = false
     # Stop mouse scroll down using hiss noise
-    user.mouse_enable_hiss_scroll = 0
+    user.mouse_enable_hiss_scroll = false
 
 #================================================================================
 # Commands to wake Talon

--- a/plugin/mode_indicator/README.md
+++ b/plugin/mode_indicator/README.md
@@ -27,7 +27,7 @@ Other modes
 ## Usage
 
 You can enable this by changing the following setting in `mode_indicator.talon`:
-`user.mode_indicator_show = 1`
+`user.mode_indicator_show = true`
 
 ## Demo
 

--- a/plugin/mode_indicator/mode_indicator.talon
+++ b/plugin/mode_indicator/mode_indicator.talon
@@ -1,6 +1,6 @@
 settings():
     # Don't show mode indicator by default
-    user.mode_indicator_show = 0
+    user.mode_indicator_show = false
     # 30pixels diameter
     user.mode_indicator_size = 30
     # Center horizontally

--- a/plugin/mouse/mouse.py
+++ b/plugin/mouse/mouse.py
@@ -55,8 +55,8 @@ mod.setting(
 )
 mod.setting(
     "mouse_enable_pop_stops_scroll",
-    type=int,
-    default=0,
+    type=bool,
+    default=False,
     desc="When enabled, pop stops continuous scroll modes (wheel upper/downer/gaze)",
 )
 mod.setting(
@@ -67,14 +67,14 @@ mod.setting(
 )
 mod.setting(
     "mouse_wake_hides_cursor",
-    type=int,
-    default=0,
+    type=bool,
+    default=False,
     desc="When enabled, mouse wake will hide the cursor. mouse_wake enables zoom mouse.",
 )
 mod.setting(
     "mouse_hide_mouse_gui",
-    type=int,
-    default=0,
+    type=bool,
+    default=False,
     desc="When enabled, the 'Scroll Mouse' GUI will not be shown.",
 )
 mod.setting(
@@ -126,7 +126,7 @@ class Actions:
         """Enable control mouse, zoom mouse, and disables cursor"""
         actions.tracking.control_zoom_toggle(True)
 
-        if settings.get("user.mouse_wake_hides_cursor") >= 1:
+        if settings.get("user.mouse_wake_hides_cursor"):
             show_cursor_helper(False)
 
     def mouse_drag(button: int):
@@ -170,7 +170,7 @@ class Actions:
         if scroll_job is None:
             start_scroll()
 
-        if settings.get("user.mouse_hide_mouse_gui") == 0:
+        if not settings.get("user.mouse_hide_mouse_gui"):
             gui_wheel.show()
 
     def mouse_scroll_up(amount: float = 1):
@@ -185,7 +185,7 @@ class Actions:
 
         if scroll_job is None:
             start_scroll()
-        if settings.get("user.mouse_hide_mouse_gui") == 0:
+        if not settings.get("user.mouse_hide_mouse_gui"):
             gui_wheel.show()
 
     def mouse_scroll_left(amount: float = 1):
@@ -210,7 +210,7 @@ class Actions:
         continuous_scoll_mode = "gaze scroll"
 
         start_cursor_scrolling()
-        if settings.get("user.mouse_hide_mouse_gui") == 0:
+        if not settings.get("user.mouse_hide_mouse_gui"):
             gui_wheel.show()
 
         # enable 'control mouse' if eye tracker is present and not enabled already
@@ -278,7 +278,7 @@ def show_cursor_helper(show):
 @ctx.action_class("user")
 class UserActions:
     def noise_trigger_pop():
-        if settings.get("user.mouse_enable_pop_stops_scroll") >= 1 and (
+        if settings.get("user.mouse_enable_pop_stops_scroll") and (
             gaze_job or scroll_job
         ):
             # Allow pop to stop scroll

--- a/plugin/talon_draft_window/draft_window.talon
+++ b/plugin/talon_draft_window/draft_window.talon
@@ -3,7 +3,7 @@ title: Talon Draft
 -
 settings():
     # Enable 'Smart dictation mode', see https://github.com/talonhub/community/pull/356
-    user.context_sensitive_dictation = 1
+    user.context_sensitive_dictation = true
 
 # Replace a single word with a phrase
 replace <user.draft_anchor> with <user.text>:

--- a/settings.talon
+++ b/settings.talon
@@ -3,7 +3,7 @@ settings():
     imgui.scale = 1.3
 
     # Enable if you'd like the picker gui to automatically appear when explorer has focus
-    user.file_manager_auto_show_pickers = 0
+    user.file_manager_auto_show_pickers = false
 
     # Set the max number of command lines per page in help
     user.help_max_command_lines_per_page = 50
@@ -15,7 +15,7 @@ settings():
     user.mouse_continuous_scroll_amount = 80
 
     # Stop continuous scroll/gaze scroll with a pop
-    user.mouse_enable_pop_stops_scroll = 1
+    user.mouse_enable_pop_stops_scroll = true
 
     # Enable pop click with 'control mouse' mode.
     # 0 = off
@@ -24,13 +24,13 @@ settings():
     user.mouse_enable_pop_click = 1
 
     # Enable if you like to use the hissing noise to do mouse scroll
-    user.mouse_enable_hiss_scroll = 0
+    user.mouse_enable_hiss_scroll = false
 
     # When enabled, the 'Scroll Mouse' GUI will not be shown.
-    user.mouse_hide_mouse_gui = 0
+    user.mouse_hide_mouse_gui = false
 
     # Hide cursor when mouse_wake is called to enable zoom mouse
-    user.mouse_wake_hides_cursor = 0
+    user.mouse_wake_hides_cursor = false
 
     # The amount to scroll up/down (equivalent to mouse wheel on Windows by default)
     user.mouse_wheel_down_amount = 120
@@ -39,7 +39,7 @@ settings():
     user.mouse_wheel_horizontal_amount = 40
 
     # Mouse grid and friends put the number one on the bottom left (vs on the top left)
-    user.grids_put_one_bottom_left = 1
+    user.grids_put_one_bottom_left = true
 
     # The number of lines of command history to display by default
     user.command_history_display = 10
@@ -61,7 +61,7 @@ settings():
     # copying surrounding text before inserting. This can be slow and may not
     # work in some applications. You may wish to enable this on a
     # per-application basis.
-    # user.context_sensitive_dictation = 1
+    # user.context_sensitive_dictation = true
 
     # How to resize windows moved across physical screens (eg. via `snap next`).
     # Default is 'proportional', which preserves window size : screen size ratio.

--- a/tags/file_manager/file_manager.py
+++ b/tags/file_manager/file_manager.py
@@ -33,8 +33,8 @@ words_to_exclude = [
 
 mod.setting(
     "file_manager_auto_show_pickers",
-    type=int,
-    default=0,
+    type=bool,
+    default=False,
     desc="Enable to show the file/directories pickers automatically",
 )
 mod.setting(
@@ -338,7 +338,7 @@ def clear_lists():
 
 
 def update_gui():
-    if gui_folders.showing or settings.get("user.file_manager_auto_show_pickers") >= 1:
+    if gui_folders.showing or settings.get("user.file_manager_auto_show_pickers"):
         gui_folders.show()
         gui_files.show()
 


### PR DESCRIPTION
Turn boolean settings in `mouse.py` and `file_manager.py` into proper booleans. For now, I've held off on converting the corresponding  `.talon` settings to boolean literals per #1296, but happy to do that too if there are no concerns.