### PR TITLE
Clarify file location of websites.csv

### DIFF
--- a/core/websites_and_search_engines/websites_and_search_engines.py
+++ b/core/websites_and_search_engines/websites_and_search_engines.py
@@ -13,7 +13,7 @@ mod.list(
 )
 
 # Please do not edit these defaults.  Instead, add / edit your own entries in
-# settings/websites.csv in your user directory.
+# websites.csv in your user/community/settings directory.
 website_defaults = {
     "talon home page": "http://talonvoice.com",
     "talon slack": "http://talonvoice.slack.com/messages/help",


### PR DESCRIPTION
I have updated the comment here to make it clear that the `websites.csv` file is in the `community/settings` directory. Hopefully this will make it obvious to new users that `websites.csv` cannot be created just anywhere like `.talon` files can.