### PR TITLE
added app name Caja (fork of Nautilus)

### DIFF
--- a/apps/nautilus/nautilus.py
+++ b/apps/nautilus/nautilus.py
@@ -7,6 +7,8 @@ os: linux
 and app.exe: nautilus
 os: linux
 and app.name: Org.gnome.Nautilus
+os: linux
+and app.name: Caja
 """
 
 # Context matching


### PR DESCRIPTION
on Linux Mint MATE the default file explorer is a fork of Nautilus and is called Caja