### PR TITLE
added app name Mate-terminal (fork of Gnome-terminal)

### DIFF
--- a/apps/gnome_terminal/gnome_terminal.py
+++ b/apps/gnome_terminal/gnome_terminal.py
@@ -7,6 +7,8 @@ os: linux
 and app.exe: gnome-terminal-server
 os: linux
 and app.name: Gnome-terminal
+os: linux
+and app.name: Mate-terminal
 """
 
 # Context matching


### PR DESCRIPTION
on Linux Mint MATE the default terminal app is a fork of Gnome-terminal and is called Mate-terminal