### PR TITLE
Remove unused setting from c code language

### DIFF
--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -1,12 +1,6 @@
 from talon import Context, Module, actions, settings
 
 mod = Module()
-mod.setting(
-    "use_stdint_datatypes ",
-    type=int,
-    default=1,
-    desc="Use the stdint datatype naming in commands by default",
-)
 
 ctx = Context()
 ctx.matches = r"""

--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -24,8 +24,6 @@ settings():
     user.code_private_variable_formatter = "SNAKE_CASE"
     user.code_protected_variable_formatter = "SNAKE_CASE"
     user.code_public_variable_formatter = "SNAKE_CASE"
-    # whether or not to use uint_8 style datatypes
-    #    user.use_stdint_datatypes = 1
 
 # NOTE: migrated from generic, as they were only used here, though once cpp support is added, perhaps these should be migrated to a tag together with the commands below
 state include: insert("#include ")


### PR DESCRIPTION
Removes a [dead setting](https://github.com/talonhub/community/pull/1360#issuecomment-1902757989) from the c code language.