### PR TITLE
Fix typo in `mouse.py` variable name

### DIFF
--- a/plugin/mouse/mouse.py
+++ b/plugin/mouse/mouse.py
@@ -96,12 +96,12 @@ mod.setting(
     desc="The amount to scroll left/right",
 )
 
-continuous_scoll_mode = ""
+continuous_scroll_mode = ""
 
 
 @imgui.open(x=700, y=0)
 def gui_wheel(gui: imgui.GUI):
-    gui.text(f"Scroll mode: {continuous_scoll_mode}")
+    gui.text(f"Scroll mode: {continuous_scroll_mode}")
     gui.line()
     if gui.button("Wheel Stop [stop scrolling]"):
         actions.user.mouse_scroll_stop()
@@ -163,8 +163,8 @@ class Actions:
 
     def mouse_scroll_down_continuous():
         """Scrolls down continuously"""
-        global continuous_scoll_mode
-        continuous_scoll_mode = "scroll down continuous"
+        global continuous_scroll_mode
+        continuous_scroll_mode = "scroll down continuous"
         mouse_scroll(settings.get("user.mouse_continuous_scroll_amount"))()
 
         if scroll_job is None:
@@ -179,8 +179,8 @@ class Actions:
 
     def mouse_scroll_up_continuous():
         """Scrolls up continuously"""
-        global continuous_scoll_mode
-        continuous_scoll_mode = "scroll up continuous"
+        global continuous_scroll_mode
+        continuous_scroll_mode = "scroll up continuous"
         mouse_scroll(-settings.get("user.mouse_continuous_scroll_amount"))()
 
         if scroll_job is None:
@@ -206,8 +206,8 @@ class Actions:
 
     def mouse_gaze_scroll():
         """Starts gaze scroll"""
-        global continuous_scoll_mode
-        continuous_scoll_mode = "gaze scroll"
+        global continuous_scroll_mode
+        continuous_scroll_mode = "gaze scroll"
 
         start_cursor_scrolling()
         if not settings.get("user.mouse_hide_mouse_gui"):
@@ -316,7 +316,7 @@ class UserActions:
 def mouse_scroll(amount):
     def scroll():
         global scroll_amount
-        if continuous_scoll_mode:
+        if continuous_scroll_mode:
             if (scroll_amount >= 0) == (amount >= 0):
                 scroll_amount += amount
             else:
@@ -370,7 +370,7 @@ def gaze_scroll():
 
 
 def stop_scroll():
-    global scroll_amount, scroll_job, gaze_job, continuous_scoll_mode
+    global scroll_amount, scroll_job, gaze_job, continuous_scroll_mode
     scroll_amount = 0
     if scroll_job:
         cron.cancel(scroll_job)
@@ -387,7 +387,7 @@ def stop_scroll():
     gaze_job = None
     gui_wheel.hide()
 
-    continuous_scoll_mode = ""
+    continuous_scroll_mode = ""
 
 
 def start_cursor_scrolling():


### PR DESCRIPTION
Changes `continuous_scoll_mode` with a missing `r` to `continuous_scroll_mode`.