### PR TITLE
Update app_name_overrides.windows.csv to use Windows Terminal instead of iTerm2

### DIFF
--- a/core/app_switcher/app_name_overrides.windows.csv
+++ b/core/app_switcher/app_name_overrides.windows.csv
@@ -1,5 +1,5 @@
 grip, DataGrip
-term, iTerm2
+term, WindowsTerminal.exe
 one note, ONENOTE
 lock, slack.exe
 app, slack.exe


### PR DESCRIPTION
It doesn't appear iTerm is available on Windows, so this should be safe to change.