### PR TITLE
Improved retrieval of current path from Windows File Explorer

### DIFF
--- a/apps/windows_explorer/windows_explorer.py
+++ b/apps/windows_explorer/windows_explorer.py
@@ -1,6 +1,7 @@
 import os
+import re
 
-from talon import Context, Module, actions, app, ui
+from talon import Context, Module, actions, app, ui, windows
 
 mod = Module()
 apps = mod.apps
@@ -28,6 +29,34 @@ ctx.matches = r"""
 app: windows_explorer
 app: windows_file_browser
 """
+
+# There are a few different ways the address bar needs to be found depending on the state of the window.
+address_bar_criterion: list[list[dict[str]]] = [
+
+        # File Explorer windows most of the time
+        [
+            {},  # Match any element for the root element
+            {'automation_id': '40965'},  # 'class_name': 'ReBarWindow32'
+            {'automation_id': '41477'},  # 'class_name': 'Address Band Root'
+            {'class_name': 'msctls_progress32'},  # Progress bar
+            {'class_name': 'Breadcrumb Parent'},  # Breadcrumb bar
+            {'automation_id': '1001'}  # 'ToolbarWindow32'
+        ],
+
+        # File Explorer window when the address bar dropdown is open
+        [
+            {},  # Match any element for the root element
+            {'automation_id': '40965'},  # ReBarWindow32
+            {'automation_id': '41477'},  # Address Band Root
+            {'class_name': 'msctls_progress32'},  # Progress bar
+            {'name': 'Address band toolbar', 'class_name': 'ToolbarWindow32'},  # Address band toolbar
+            {'control_type': 'Button', 'name': re.compile(r"Refresh .+ \(F5\)")}  # Refresh button
+        ],
+        # Title change events have the 'Address toolbar' as the root element
+        [
+            {'automation_id': '1001'}  # 'class_name': 'ToolbarWindow32'
+        ],
+    ]
 
 user_path = os.path.expanduser("~")
 directories_to_remap = {}
@@ -96,7 +125,10 @@ class UserActions:
         actions.key("alt-up")
 
     def file_manager_current_path():
-        path = ui.active_window().title
+        path = get_explorer_directory(ui.active_window())
+        if path is None:
+            # Fallback to the title of the window if the address could not be found
+            path = ui.active_window().title
 
         if path in directories_to_remap:
             path = directories_to_remap[path]
@@ -146,3 +178,87 @@ class UserActions:
     def file_manager_open_volume(volume: str):
         """file_manager_open_volume"""
         actions.user.file_manager_open_directory(volume)
+
+def get_explorer_directory(window: ui.Window) -> str | None:
+    """
+    Returns the current directory in the given Windows Explorer window from the Address toolbar.
+    """
+
+    # Find the Address toolbar element
+    current_element = None
+    for element_navigator in address_bar_criterion:
+        first_criteria = element_navigator[0]
+
+        if not check_if_element_strictly_matches(window.element, **first_criteria):
+            continue
+        current_element = window.element
+        for criterion in element_navigator[1:]:
+            current_element = first_matching_child(current_element, **criterion)
+            if current_element is None:
+                break
+
+        if current_element is not None:
+            break
+
+    if current_element is None:
+        # The Address toolbar could not be found
+        return None
+
+    # Get the text from the Address toolbar or refresh button
+    path = None
+    if current_element.automation_id == "1001":
+        path = current_element.name.replace("Address: ", "")
+    elif current_element.control_type == "Button":
+        path = current_element.name.replace('Refresh "', "").replace('" (F5)', "")
+
+    return path
+
+
+def check_if_element_strictly_matches(element: windows.ax.Element, **kw) -> bool:
+    """
+    Returns True if the given element matches all the given attribute-value pairs.
+    The value of a pair may be a string or a regex pattern.
+
+    Example:
+        ```
+        channel_element_name: re.Pattern = re.compile(r"(.+?).\\(channel\\)")
+        element_matches: bool = check_if_element_strictly_matches(element, name=channel_element_name, control_type="Group")
+        ```
+        This will return True if the given `element` has an attribute `name`
+          that matches the given regex pattern and `control_type` with the value "Group".
+
+        ```
+        element_matches: bool = check_if_element_strictly_matches(element, name="Channels", control_type="Group")
+        ```
+        This will return True if the given `element` has an attribute `name`
+          with the value "Channels" and `control_type` with the value "Group".
+    """
+
+    # Iterate through the children of the element, checking if each one matches all the given attribute-value pairs
+    for attr_name, match_value in kw.items():
+        element_attr_value = getattr(element, attr_name)
+        if isinstance(match_value, re.Pattern):
+            if not match_value.search(element_attr_value):
+                return False
+        elif match_value != element_attr_value:
+            return False
+    return True
+
+def first_matching_child(element: windows.ax.Element, **kw) -> windows.ax.Element | None:
+    """
+    Returns the first child element of `element` that matches all the given attribute-value pairs.
+    The value may be a string or a regex pattern.
+
+    Example:
+        ```python
+        child = first_matching_child(element, name="Channels", control_type="Group")
+        ```
+        This will return the first child of `element` that has an attribute `name` 
+           with the value "Channels" and `control_type` with the value "Group".
+    """
+
+    return next(
+        (
+            e for e in element.children if check_if_element_strictly_matches(e, **kw)
+        ), None
+    )

--- a/apps/windows_explorer/windows_explorer.py
+++ b/apps/windows_explorer/windows_explorer.py
@@ -1,6 +1,7 @@
 import os
+import re
 
-from talon import Context, Module, actions, app, ui
+from talon import Context, Module, actions, app, ui, windows
 
 mod = Module()
 apps = mod.apps
@@ -28,6 +29,34 @@ ctx.matches = r"""
 app: windows_explorer
 app: windows_file_browser
 """
+
+# There are a few different ways the address bar needs to be found depending on the state of the window.
+address_bar_criterion: list[list[dict[str]]] = [
+
+        # File Explorer windows most of the time
+        [
+            {},  # Match any element for the root element
+            {'automation_id': '40965'},  # 'class_name': 'ReBarWindow32'
+            {'automation_id': '41477'},  # 'class_name': 'Address Band Root'
+            {'class_name': 'msctls_progress32'},  # Progress bar
+            {'class_name': 'Breadcrumb Parent'},  # Breadcrumb bar
+            {'automation_id': '1001'}  # 'ToolbarWindow32'
+        ],
+
+        # File Explorer window when the address bar dropdown is open
+        [
+            {},  # Match any element for the root element
+            {'automation_id': '40965'},  # ReBarWindow32
+            {'automation_id': '41477'},  # Address Band Root
+            {'class_name': 'msctls_progress32'},  # Progress bar
+            {'name': 'Address band toolbar', 'class_name': 'ToolbarWindow32'},  # Address band toolbar
+            {'control_type': 'Button', 'name': re.compile(r"Refresh .+ \(F5\)")}  # Refresh button
+        ],
+        # Title change events have the 'Address toolbar' as the root element
+        [
+            {'automation_id': '1001'}  # 'class_name': 'ToolbarWindow32'
+        ],
+    ]
 
 user_path = os.path.expanduser("~")
 directories_to_remap = {}
@@ -96,7 +125,10 @@ class UserActions:
         actions.key("alt-up")
 
     def file_manager_current_path():
-        path = ui.active_window().title
+        path = get_explorer_directory(ui.active_window())
+        if path is None:
+            # Fallback to the title of the window if the address could not be found
+            path = ui.active_window().title
 
         if path in directories_to_remap:
             path = directories_to_remap[path]
@@ -146,3 +178,81 @@ class UserActions:
     def file_manager_open_volume(volume: str):
         """file_manager_open_volume"""
         actions.user.file_manager_open_directory(volume)
+
+def get_explorer_directory(window: ui.Window) -> str | None:
+    """
+    Returns the current directory in the given Windows Explorer window from the Address toolbar.
+    """
+
+    # Find the Address toolbar element
+    current_element = None
+    for element_navigator in address_bar_criterion:
+        first_criteria = element_navigator[0]
+
+        if not check_if_element_strictly_matches(window.element, **first_criteria):
+            continue
+        current_element = window.element
+        for criterion in element_navigator[1:]:
+            current_element = first_matching_child(current_element, **criterion)
+            if current_element is None:
+                break
+
+        if current_element is not None:
+            break
+
+    if current_element is None:
+        # The Address toolbar could not be found
+        return None
+
+    # Get the text from the Address toolbar or refresh button
+    path = None
+    if current_element.automation_id == "1001":
+        path = current_element.name.replace("Address: ", "")
+    elif current_element.control_type == "Button":
+        path = current_element.name.replace('Refresh "', "").replace('" (F5)', "")
+
+    return path
+
+
+def check_if_element_strictly_matches(element: windows.ax.Element, **kw) -> bool:
+    """
+    Returns True if the given element matches all the given attribute-value pairs.
+    The value of a pair may be a string or a regex pattern.
+
+    Example:
+        ```
+        channel_element_name: re.Pattern = re.compile(r"(.+?).\\(channel\\)")
+        element_matches: bool = check_if_element_matches(element, name=channel_element_name, control_type="Group")
+        ```
+        This will return True if the given `element` has an attribute `name`
+          that matches the given regex pattern and `control_type` with the value "Group".
+    """
+
+    # Iterate through the children of the element, checking if each one matches all the given attribute-value pairs
+    for attr_name, match_value in kw.items():
+        element_attr_value = getattr(element, attr_name)
+        if isinstance(match_value, re.Pattern):
+            if not match_value.search(element_attr_value):
+                return False
+        elif match_value != element_attr_value:
+            return False
+    return True
+
+def first_matching_child(element: windows.ax.Element, **kw) -> windows.ax.Element | None:
+    """
+    Returns the first child element of `element` that matches all the given attribute-value pairs.
+    The value may be a string or a regex pattern.
+
+    Example:
+        ```python
+        child = first_matching_child_ma(element, name="Channels", control_type="Group")
+        ```
+        This will return the first child of `element` that has an attribute `name` 
+           with the value "Channels" and `control_type` with the value "Group".
+    """
+
+    return next(
+        (
+            e for e in element.children if check_if_element_strictly_matches(e, **kw)
+        ), None
+    )

--- a/apps/windows_explorer/windows_explorer.py
+++ b/apps/windows_explorer/windows_explorer.py
@@ -32,31 +32,33 @@ app: windows_file_browser
 
 # There are a few different ways the address bar needs to be found depending on the state of the window.
 address_bar_criterion: list[list[dict[str]]] = [
-
-        # File Explorer windows most of the time
-        [
-            {},  # Match any element for the root element
-            {'automation_id': '40965'},  # 'class_name': 'ReBarWindow32'
-            {'automation_id': '41477'},  # 'class_name': 'Address Band Root'
-            {'class_name': 'msctls_progress32'},  # Progress bar
-            {'class_name': 'Breadcrumb Parent'},  # Breadcrumb bar
-            {'automation_id': '1001'}  # 'ToolbarWindow32'
-        ],
-
-        # File Explorer window when the address bar dropdown is open
-        [
-            {},  # Match any element for the root element
-            {'automation_id': '40965'},  # ReBarWindow32
-            {'automation_id': '41477'},  # Address Band Root
-            {'class_name': 'msctls_progress32'},  # Progress bar
-            {'name': 'Address band toolbar', 'class_name': 'ToolbarWindow32'},  # Address band toolbar
-            {'control_type': 'Button', 'name': re.compile(r"Refresh .+ \(F5\)")}  # Refresh button
-        ],
-        # Title change events have the 'Address toolbar' as the root element
-        [
-            {'automation_id': '1001'}  # 'class_name': 'ToolbarWindow32'
-        ],
-    ]
+    # File Explorer windows most of the time
+    [
+        {},  # Match any element for the root element
+        {"automation_id": "40965"},  # 'class_name': 'ReBarWindow32'
+        {"automation_id": "41477"},  # 'class_name': 'Address Band Root'
+        {"class_name": "msctls_progress32"},  # Progress bar
+        {"class_name": "Breadcrumb Parent"},  # Breadcrumb bar
+        {"automation_id": "1001"},  # 'ToolbarWindow32'
+    ],
+    # File Explorer window when the address bar dropdown is open
+    [
+        {},  # Match any element for the root element
+        {"automation_id": "40965"},  # ReBarWindow32
+        {"automation_id": "41477"},  # Address Band Root
+        {"class_name": "msctls_progress32"},  # Progress bar
+        {
+            "name": "Address band toolbar",
+            "class_name": "ToolbarWindow32",
+        },  # Address band toolbar
+        {
+            "control_type": "Button",
+            "name": re.compile(r"Refresh .+ \(F5\)"),
+        },  # Refresh button
+    ],
+    # Title change events have the 'Address toolbar' as the root element
+    [{"automation_id": "1001"}],  # 'class_name': 'ToolbarWindow32'
+]
 
 user_path = os.path.expanduser("~")
 directories_to_remap = {}
@@ -179,6 +181,7 @@ class UserActions:
         """file_manager_open_volume"""
         actions.user.file_manager_open_directory(volume)
 
+
 def get_explorer_directory(window: ui.Window) -> str | None:
     """
     Returns the current directory in the given Windows Explorer window from the Address toolbar.
@@ -244,7 +247,10 @@ def check_if_element_strictly_matches(element: windows.ax.Element, **kw) -> bool
             return False
     return True
 
-def first_matching_child(element: windows.ax.Element, **kw) -> windows.ax.Element | None:
+
+def first_matching_child(
+    element: windows.ax.Element, **kw
+) -> windows.ax.Element | None:
     """
     Returns the first child element of `element` that matches all the given attribute-value pairs.
     The value may be a string or a regex pattern.
@@ -253,12 +259,11 @@ def first_matching_child(element: windows.ax.Element, **kw) -> windows.ax.Elemen
         ```python
         child = first_matching_child(element, name="Channels", control_type="Group")
         ```
-        This will return the first child of `element` that has an attribute `name` 
+        This will return the first child of `element` that has an attribute `name`
            with the value "Channels" and `control_type` with the value "Group".
     """
 
     return next(
-        (
-            e for e in element.children if check_if_element_strictly_matches(e, **kw)
-        ), None
+        (e for e in element.children if check_if_element_strictly_matches(e, **kw)),
+        None,
     )


### PR DESCRIPTION
The old implementation of retrieving the current path from the title of the active File Explorer window only worked as long as the path was under 100 characters. Otherwise the title got truncated and no longer matched a valid path. This adds a new method of getting the path by pulling it directly from the address bar using accessibility elements.

I'm not sure if this works on Windows 11 as I am unable to test that currently. I suspect that with the large amount of changes that have been made to File Explorer it will likely need some adjustments to work properly on Windows 11. However, it should gracefully fall back to the old method if the address bar elements cannot be found.
