### PR TITLE
For vscode, define the filename as the first window title component containing a dot.

### DIFF
--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -137,14 +137,10 @@ class WinActions:
         # if title == "":
         #    title = ui.active_window().doc
 
-        if is_mac:
-            result = title.split(" — ")[0]
-        else:
-            result = title.split(" - ")[0]
-
-        if "." in result:
-            return result
-
+        sep = " — " if is_mac else " - "
+        dots = [comp for comp in title.split(sep) if "." in comp]
+        if len(dots) > 0:
+            return dots[0]
         return ""
 
 


### PR DESCRIPTION
The VS Code title format is configurable and does not always contain the filename as the first component. This change preserves existing behavior when the filename is the first component but also supports it in other positions.