### PR TITLE
jetbrains: reduce log output, better error output

### DIFF
--- a/apps/jetbrains/jetbrains.py
+++ b/apps/jetbrains/jetbrains.py
@@ -76,11 +76,15 @@ def _get_nonce(port):
                     errors_encountered.append(e)
     if nonce is None:
         if any_file_existed:
-            print("could not read voicecode-idea nonce file! jetbrains commands will not work!")
+            print(
+                "could not read voicecode-idea nonce file! jetbrains commands will not work!"
+            )
             for e in errors_encountered:
                 print("  ", e)
         else:
-            print(f"Could not find any voicecode-idea nonce files, .vcidea_{port} or vcidea_{port} in {' or '.join(locations)}! jetbrains commands will not work!")
+            print(
+                f"Could not find any voicecode-idea nonce files, .vcidea_{port} or vcidea_{port} in {' or '.join(locations)}! jetbrains commands will not work!"
+            )
     return nonce
 
 
@@ -89,7 +93,9 @@ def send_idea_command(cmd):
     bundle = active_app.bundle or active_app.name
     port = port_mapping.get(bundle, None)
     if port is None:
-        print(f"could not figure out port to use for jetbrains application '{bundle}'; vscode-idea commands will not work!")
+        print(
+            f"could not figure out port to use for jetbrains application '{bundle}'; vscode-idea commands will not work!"
+        )
         return
     nonce = _get_nonce(port)
     proxies = {"http": None, "https": None}


### PR DESCRIPTION
until now, finding the vcidea_foo file still resulted in an error that the .vcidea_foo file was not found, which is confusing. also, there's always many lines per command executed, with this patch it's just one when it works.
If there's an error with the vcidea nonce file, or if the port isn't found, there will now be a hint that vscode-idea commands will not work, and when the vcidea file is not found, the actual locations we looked will be put into the log message as well, so you don't have to guess or investigate with the REPL or something