### PR TITLE
context-sensitive dictation: default to not inserting space

### DIFF
--- a/core/text/text_and_dictation.py
+++ b/core/text/text_and_dictation.py
@@ -442,13 +442,13 @@ class Actions:
             if before:
                 # Unfortunately, in web Slack, if our selection ends at newline, this
                 # will go right over the newline. Argh.
-                actions.edit.right() # cancel selection
+                actions.edit.right()  # cancel selection
 
         if not right:
-            actions.key(f"backspace:{len(dummy)}") # remove the dummy
+            actions.key(f"backspace:{len(dummy)}")  # remove the dummy
         else:
             for _ in dummy:
-                actions.edit.left()         # go left before dummy
+                actions.edit.left()  # go left before dummy
             # We want to select at least two characters to the right, plus the dummy we
             # inserted, because no_space_before needs two characters in the worst case
             # -- for example, inserting before "' hello" we don't want to add space,
@@ -470,7 +470,7 @@ class Actions:
             actions.edit.extend_word_right()
             after = actions.edit.selected_text()
             if after:
-                actions.edit.left()             # cancel selection
-            actions.key(f"delete:{len(dummy)}") # remove the dummy
+                actions.edit.left()  # cancel selection
+            actions.key(f"delete:{len(dummy)}")  # remove the dummy
 
         return before, after

--- a/core/text/text_and_dictation.py
+++ b/core/text/text_and_dictation.py
@@ -434,6 +434,8 @@ class Actions:
             # key(shift-up) doesn't work consistently in the Slack webapp (sometimes
             # escapes the text box).
             if dummy and not dummy.isspace():
+                # If the dummy is all spaces, extend_word_left should select it.
+                # Otherwise, select it manually.
                 for _ in dummy:
                     actions.edit.extend_left()
             actions.edit.extend_word_left()

--- a/core/text/text_and_dictation.py
+++ b/core/text/text_and_dictation.py
@@ -255,9 +255,9 @@ def auto_capitalize(text, state=None):
         newline = c == "\n"
         sentence_end = c in ".!?" and not no_cap_after.search(output)
     return output, (
-        "sentence start" if charge or sentence_end else
-        "after newline" if newline else
-        None
+        "sentence start"
+        if charge or sentence_end
+        else "after newline" if newline else None
     )
 
 
@@ -452,7 +452,7 @@ class Actions:
                 # will go right over the newline. Argh.
                 actions.edit.right()  # cancel selection
             if dummy:
-                before = before[:-len(dummy)]
+                before = before[: -len(dummy)]
 
         if not right:
             actions.key(f"backspace:{len(dummy)}")  # remove the dummy
@@ -480,9 +480,9 @@ class Actions:
             actions.edit.extend_word_right()
             after = actions.edit.selected_text()
             if after:
-                actions.edit.left()             # cancel selection
+                actions.edit.left()  # cancel selection
             if dummy:
-                after = after[len(dummy):]
-                actions.key(f"delete:{len(dummy)}") # remove the dummy
+                after = after[len(dummy) :]
+                actions.key(f"delete:{len(dummy)}")  # remove the dummy
 
         return before, after

--- a/settings.talon
+++ b/settings.talon
@@ -61,6 +61,12 @@ settings():
     # wish to enable this on a per-application basis.
     # user.context_sensitive_dictation = true
 
+    # Uncomment this to have context-sensitive dictation insert a dummy string before it
+    # selects surrounding text. This avoids copying with an empty selection, which
+    # misbehaves in some applications; however, it also slows down context-sensitive
+    # dictation and can clutter the undo history.
+    # user.context_sensitive_dictation_dummy_string = " "
+
     # Choose how to resize windows moved across physical screens (eg. via `snap next`).
     # Default is 'proportional', which preserves window size : screen size ratio.
     # 'size aware' keeps absolute window size the same, except full-height or


### PR DESCRIPTION
Currently `dictation_peek` in context-sensitive dictation inserts a space before selecting text around point. This avoids ever copying with an empty selection, which misbehaves in some applications. However:

1. This makes the whole dance noticeably slower on my machine.
2. In applications where copying an empty selection misbehaves, many of our other commands also fail to work (eg: `select line start` tries to tell whether there is currently a selection to determine whether to cancel it); working around this everywhere would kind of be a nightmare, so I tentatively think it makes more sense to have "fix your editor" be our policy on this problem.
3. In some contexts (eg: the google.com search bar), inserting a space doesn't work consistently because google "helpfully" avoids inserting a space if there already is one.

This PR defaults to *not* inserting anything, but provides a configurable setting, `user.context_sensitive_dictation_dummy_string`, for what dummy string to insert. This makes the dictation dance faster by default but allows users to choose the dummy string behavior if they want, and also to choose a dummy string that will work even in the google address bar.