### PR TITLE
define "zoom reset" for VSCode

### DIFF
--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -128,6 +128,9 @@ class EditActions:
         actions.key("enter")
         actions.edit.line_start()
 
+    def zoom_reset():
+        actions.user.vscode("workbench.action.zoomReset")
+
 
 @ctx.action_class("win")
 class WinActions:


### PR DESCRIPTION
The default value for "zoom reset"  defined in edit_win.py is "ctrl-0".  This does not work in VS Code. The PR  attempts to fix this.