### PR TITLE
enable the "user.command_client" tag for "neovim" app

### DIFF
--- a/apps/vscode/command_client/README.md
+++ b/apps/vscode/command_client/README.md
@@ -4,9 +4,11 @@ This directory contains the client code for communicating with the [VSCode comma
 
 ## Contributing
 
-The source of truth is in https://github.com/knausj85/knausj_talon/tree/main/apps/vscode/command_client, but the code is also maintained as a subtree at https://github.com/pokey/talon-vscode-command-client.
+The source of truth is in https://github.com/talonhub/community/tree/main/apps/vscode/command_client, but the code is also maintained as a subtree at https://github.com/pokey/talon-vscode-command-client.
 
-To contribute, first open a PR on knausj. Once the PR is merged, you can push the changes to the subtree by running the following commands on an up-to-date knausj main: (need write access)
+To contribute, first open a PR on `community`.
+
+Once the PR is merged, you can push the changes to the subtree by running the following commands on an up-to-date `community` main: (need write access)
 
 ```sh
 git subtree split --prefix=apps/vscode/command_client --annotate="[split] " -b split

--- a/apps/vscode/command_client/README.md
+++ b/apps/vscode/command_client/README.md
@@ -4,11 +4,9 @@ This directory contains the client code for communicating with the [VSCode comma
 
 ## Contributing
 
-The source of truth is in https://github.com/talonhub/community/tree/main/apps/vscode/command_client, but the code is also maintained as a subtree at https://github.com/pokey/talon-vscode-command-client.
+The source of truth is in https://github.com/knausj85/knausj_talon/tree/main/apps/vscode/command_client, but the code is also maintained as a subtree at https://github.com/pokey/talon-vscode-command-client.
 
-To contribute, first open a PR on `community`.
-
-Once the PR is merged, you can push the changes to the subtree by running the following commands on an up-to-date `community` main: (need write access)
+To contribute, first open a PR on knausj. Once the PR is merged, you can push the changes to the subtree by running the following commands on an up-to-date knausj main: (need write access)
 
 ```sh
 git subtree split --prefix=apps/vscode/command_client --annotate="[split] " -b split

--- a/apps/vscode/command_client/neovim.py
+++ b/apps/vscode/command_client/neovim.py
@@ -1,0 +1,18 @@
+from talon import Context, actions
+
+ctx = Context()
+
+ctx.matches = r"""
+app: neovim
+"""
+
+ctx.tags = ["user.command_client"]
+
+
+@ctx.action_class("user")
+class VimActions:
+    def command_server_directory() -> str:
+        return "neovim-command-server"
+
+    def trigger_command_server_command_execution():
+        actions.key("ctrl-q")


### PR DESCRIPTION
Pushing this file only to allow others to beta test the already packaged cursorless for neovim from https://github.com/hands-free-vim/talon.nvim/tree/beta without having to add the file manually.

Note that the app is "neovim" so it won't trigger any side effect with community which uses the "vim" app only. And the "neovim" app is only defined in https://github.com/hands-free-vim/neovim-talon so it is safe to merge now imho.

NOTE: the apps/vscode/command-client might have to move outside of the "vscode" app since it is now for other apps but it can be moved in a later PR.