### PR TITLE
micro-optimization for dictation_insert

### DIFF
--- a/core/text/text_and_dictation.py
+++ b/core/text/text_and_dictation.py
@@ -380,7 +380,7 @@ class Actions:
             # inserted text and the trailing space.
             need_left = (
                 not omit_space_before(text)
-                or text != auto_capitalize(text, "sentence start")[0]
+                or (auto_cap and text != auto_capitalize(text, "sentence start")[0])
             )
             need_right = not omit_space_after(text)
             before, after = actions.user.dictation_peek(need_left, need_right)

--- a/core/text/text_and_dictation.py
+++ b/core/text/text_and_dictation.py
@@ -378,9 +378,8 @@ class Actions:
             # peek right if we might need trailing space. NB. We peek right
             # BEFORE insertion to avoid breaking the undo-chain between the
             # inserted text and the trailing space.
-            need_left = (
-                not omit_space_before(text)
-                or (auto_cap and text != auto_capitalize(text, "sentence start")[0])
+            need_left = not omit_space_before(text) or (
+                auto_cap and text != auto_capitalize(text, "sentence start")[0]
             )
             need_right = not omit_space_after(text)
             before, after = actions.user.dictation_peek(need_left, need_right)


### PR DESCRIPTION
We avoid needing to peek left if both:

1. The string being inserted never needs space before it (eg: it is a period).
2. The string being inserted does not change under auto-capitalization.

This PR extends condition (2) to include the case where `auto_cap = False` has been passed, so we are not doing auto-capitalization at all.