### PR TITLE
Update .pre-commit-config.yaml to fix precommit error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,3 +50,4 @@ repos:
     hooks:
       - id: talonfmt
         args: ["--in-place"]
+        language_version: python3.11


### PR DESCRIPTION
Talonfmt requires Python 3.11 to be installed. This line fixes the precommit error and should make it pass. 

I tested this on the ai-tools repo and it passes now
https://github.com/C-Loftus/talon-ai-tools/blob/683638d5aa3a0ad556e747947e9909039ec3385e/.pre-commit-config.yaml#L53