### PR TITLE
More emacs commands, including xref commands (go-to-definition)

### DIFF
--- a/apps/emacs/emacs.talon
+++ b/apps/emacs/emacs.talon
@@ -299,12 +299,6 @@ visit tags table: user.emacs("visit-tags-table")
 
 # ----- PROJECT SUPPORT ----- #
 project [find] file: user.emacs("project-find-file")
-project [find] file <user.text>$:
-    user.emacs("project-find-file")
-    user.insert_formatted(text, "DASH_SEPARATED")
-project [find] file <user.text> over:
-    user.emacs("project-find-file")
-    user.insert_formatted(text, "DASH_SEPARATED")
 project [find] (regex | grep): user.emacs("project-find-regexp")
 project [query] replace regex: user.emacs("project-query-replace-regexp")
 project (dired | directory): user.emacs("projectile-dired")

--- a/apps/emacs/emacs.talon
+++ b/apps/emacs/emacs.talon
@@ -287,8 +287,24 @@ rectangle (yank | paste): user.emacs("yank-rectangle")
 rectangle copy: user.emacs("copy-rectangle-as-kill")
 rectangle number lines: user.emacs("rectangle-number-lines")
 
+# ----- XREF SUPPORT ----- #
+[xref] find definition: user.emacs("xref-find-definitions")
+[xref] find definition other window: user.emacs("xref-find-definitions-other-window")
+[xref] find definition other frame: user.emacs("xref-find-definitions-other-frame")
+[xref] find references: user.emacs("xref-find-references")
+[xref] find references [and] replace: user.emacs("xref-find-references-and-replace")
+xref find apropos: user.emacs("xref-find-apropos")
+xref go back: user.emacs("xref-go-back")
+visit tags table: user.emacs("visit-tags-table")
+
 # ----- PROJECT SUPPORT ----- #
 project [find] file: user.emacs("project-find-file")
+project [find] file <user.text>$:
+    user.emacs("project-find-file")
+    user.insert_formatted(text, "DASH_SEPARATED")
+project [find] file <user.text> over:
+    user.emacs("project-find-file")
+    user.insert_formatted(text, "DASH_SEPARATED")
 project [find] (regex | grep): user.emacs("project-find-regexp")
 project [query] replace regex: user.emacs("project-query-replace-regexp")
 project (dired | directory): user.emacs("projectile-dired")
@@ -324,7 +340,8 @@ merge next: user.emacs("smerge-next")
 merge last: user.emacs("smerge-prev")
 merge keep upper: user.emacs("smerge-keep-upper")
 merge keep lower: user.emacs("smerge-keep-lower")
-merge keep this: user.emacs("smerge-keep-current")
+merge keep base: user.emacs("smerge-keep-base")
+merge keep (this | current): user.emacs("smerge-keep-current")
 merge refine: user.emacs("smerge-refine")
 merge split: user.emacs("smerge-resolve")
 

--- a/apps/emacs/emacs_commands.csv
+++ b/apps/emacs/emacs_commands.csv
@@ -63,8 +63,8 @@ global-hl-line-mode,, g-hl-l-m
 global-visual-line-mode,, gl-v-l-m
 goto-line, meta-g meta-g
 highlight-lines-matching-regexp, meta-s h l
-highlight-regexp, meta-s h r
 highlight-phrase, meta-s h p
+highlight-regexp, meta-s h r
 hl-line-mode,, hl-l-m
 indent-region, meta-ctrl-\
 indent-rigidly, ctrl-x tab
@@ -102,6 +102,7 @@ next-buffer, ctrl-x right
 next-error, meta-g n
 occur, meta-s o
 open-rectangle, ctrl-x r o
+other-frame, ctrl-x 5 o
 other-window, ctrl-x o
 outline-backward-same-level, ctrl-c @ ctrl-b
 outline-demote, ctrl-c @ ctrl->
@@ -214,9 +215,17 @@ unhighlight-regexp, meta-s h u
 universal-argument, ctrl-u
 vc-annotate, ctrl-x v g
 view-lossage, ctrl-h l
+visit-tags-table,, v-t-t
 visual-line-mode,, visu-l-m
 whitespace-cleanup,, wh-cl
 whitespace-mode,, white-m
 widen, ctrl-x n w
+xref-find-apropos, meta-ctrl-.
+xref-find-definitions, meta-.
+xref-find-definitions-other-frame, ctrl-x 5 .
+xref-find-definitions-other-window, ctrl-x 4 .
+xref-find-references, meta-?
+xref-find-references-and-replace
+xref-go-back,"meta-,"
 yank, ctrl-y
 yank-rectangle, ctrl-x r y


### PR DESCRIPTION
Adds more emacs commands, mostly `xref` commands but also `other-frame` and `visit-tags-table`. Also sorts `emacs_commands.csv`.