### PR TITLE
allow "help last" as synonym for "help previous"

### DIFF
--- a/core/help/help_open.talon
+++ b/core/help/help_open.talon
@@ -1,7 +1,7 @@
 tag: user.help_open
 -
 help next$: user.help_next()
-help previous$: user.help_previous()
+help (previous | last)$: user.help_previous()
 help <number>$: user.help_select_index(number - 1)
 help return$: user.help_return()
 help refresh$: user.help_refresh()


### PR DESCRIPTION
We use "next/last" in various commands, but help uses "next/previous". This matches the button labels (which are "previous" because it's more self-explanatory than "last"), which is good, but is inconsistent with other commands, which is bad. I suggest we support both.