### PR TITLE
Allow apps to force lang via code.language and add special cased files

### DIFF
--- a/apps/obsidian/obsidian.py
+++ b/apps/obsidian/obsidian.py
@@ -1,13 +1,7 @@
 from talon import Context, Module
 
 mod = Module()
-apps = mod.apps
-apps.obsidian = "app.name: Obsidian"
-
-ctx = Context()
-ctx.matches = r"""
-app: obsidian
-"""
+mod.apps.obsidian = "app.name: Obsidian"
 
 lang_ctx = Context()
 lang_ctx.matches = r"""

--- a/apps/obsidian/obsidian.py
+++ b/apps/obsidian/obsidian.py
@@ -1,0 +1,22 @@
+from talon import Context, Module
+
+mod = Module()
+apps = mod.apps
+apps.obsidian = "app.name: Obsidian"
+
+ctx = Context()
+ctx.matches = r"""
+app: obsidian
+"""
+
+lang_ctx = Context()
+lang_ctx.matches = r"""
+app: obsidian
+not tag: user.code_language_forced
+"""
+
+
+@lang_ctx.action_class("code")
+class CodeActions:
+    def language():
+        return "markdown"

--- a/apps/obsidian/obsidian.talon
+++ b/apps/obsidian/obsidian.talon
@@ -1,0 +1,3 @@
+app: obsidian
+-
+tag(): user.tabs

--- a/core/modes/language_modes.py
+++ b/core/modes/language_modes.py
@@ -141,7 +141,7 @@ class Actions:
 
     def code_show_forced_language_mode():
         """Show the active language for this context"""
-        if forced_language
+        if forced_language:
             app.notify(f"Forced language: {forced_language}")
         else:
             app.notify("No language forced")

--- a/core/modes/language_modes.py
+++ b/core/modes/language_modes.py
@@ -1,4 +1,4 @@
-from talon import Context, Module, actions
+from talon import Context, Module, actions, app
 
 # Maps language mode names to the extensions that activate them. Only put things
 # here which have a supported language mode; that's why there are so many
@@ -49,6 +49,19 @@ language_extensions = {
     "html": "html",
 }
 
+# Files without specific extensions but are associated with languages
+special_file_map = {
+    "CMakeLists.txt": "cmake",
+    "Makefile": "make",
+    "Dockerfile": "docker",
+    "meson.build": "meson",
+    ".bashrc": "bash",
+    ".zshrc": "zsh",
+    "PKGBUILD": "pkgbuild",
+    ".vimrc": "vimscript",
+    "vimrc": "vimscript",
+}
+
 # Override speakable forms for language modes. If not present, a language mode's
 # name is used directly.
 language_name_overrides = {
@@ -57,12 +70,12 @@ language_name_overrides = {
     "css": ["c s s"],
     "gdb": ["g d b"],
     "go": ["go", "go lang", "go language"],
-    "r": ["are language"],
+    "r": ["are lang", "are language"],
+    "scm": ["scheme", "s c m", "tree sitter"],
     "tex": ["tech", "lay tech", "latex"],
 }
 
 mod = Module()
-
 ctx = Context()
 
 ctx_forced = Context()
@@ -95,6 +108,10 @@ forced_language = ""
 @ctx.action_class("code")
 class CodeActions:
     def language():
+        file_name = actions.win.filename()
+        if file_name in special_file_map:
+            return special_file_map[file_name]
+
         file_extension = actions.win.file_ext()
         return extension_lang_map.get(file_extension, "")
 
@@ -122,3 +139,8 @@ class Actions:
         global forced_language
         forced_language = ""
         ctx.tags = []
+
+    def code_show_forced_language_mode():
+        """Show the active language for this context"""
+        if forced_language
+            app.notify(f"Forced language: {forced_language}")

--- a/core/modes/language_modes.py
+++ b/core/modes/language_modes.py
@@ -70,8 +70,7 @@ language_name_overrides = {
     "css": ["c s s"],
     "gdb": ["g d b"],
     "go": ["go", "go lang", "go language"],
-    "r": ["are lang", "are language"],
-    "scm": ["scheme", "s c m", "tree sitter"],
+    "r": ["are language"],
     "tex": ["tech", "lay tech", "latex"],
 }
 
@@ -144,3 +143,5 @@ class Actions:
         """Show the active language for this context"""
         if forced_language
             app.notify(f"Forced language: {forced_language}")
+        else:
+            app.notify("No language forced")

--- a/core/modes/language_modes.talon
+++ b/core/modes/language_modes.talon
@@ -1,2 +1,3 @@
 ^force {user.language_mode}$: user.code_set_language_mode(language_mode)
+show [forced] language modes: user.code_show_forced_language_mode()
 ^clear language modes$: user.code_clear_language_mode()

--- a/core/modes/language_modes.talon
+++ b/core/modes/language_modes.talon
@@ -1,3 +1,3 @@
 ^force {user.language_mode}$: user.code_set_language_mode(language_mode)
-show [forced] language modes: user.code_show_forced_language_mode()
-^clear language modes$: user.code_clear_language_mode()
+show [forced] language mode: user.code_show_forced_language_mode()
+^clear language mode$: user.code_clear_language_mode()


### PR DESCRIPTION
This makes some tweaks to language modes:

1. It adds a list of special-cased files that are mixed into the determination of the language, so you can return a language for things even if the file extension itself doesn't imply the language. The languages included aren't actually implemented in community, so I can keep the list empty if preferred, but I figured I'd keep it populated at first to give an example of why it's useful.
2. Adds a command to show the currently forced language
3. #1256 semi-recently went the route of removing language-specific tags. This has the side effect (afaict) that an app that doesn't expose the file extension in its title can no longer force a language (previously it would just `tag: user.<lang>`). Given we removed the tags I assume we don't want them back, so this change goes a different route and adds an action that can be overridden to force a language. It's done in a way that the language being forced by an app will still be overridden by a user manually forcing a language with `force <lang>`. I've included an obsidian skeleton to demonstrate how to use it. Obsidian is a markdown editor that doesn't include file extensions in it's title. I took a look at search.talonvoice.com and see that some people are using tag.markdown (so are their community is not up to date, or they custom implemented tags again) and some others are re-implementing markdown commands. Since I tried to use this app recently, and I don't like forcing a language across my entire system and have to remember to clear it afterwards, I figured I should add a way to do it.

I'm open to other ways to do this if there is a better idea.