### PR TITLE
Use active list with help_list

### DIFF
--- a/core/help/help.py
+++ b/core/help/help.py
@@ -484,7 +484,7 @@ def draw_list_commands(gui: imgui.GUI):
     global total_page_count
     global selected_context_page
 
-    talon_list = registry.lists[selected_list][0]
+    talon_list = registry.lists[selected_list][-1]
     # numpages = math.ceil(len(talon_list) / SIZE)
 
     pages_list = []


### PR DESCRIPTION
Currently if the user uses  `user.help_list()` and passes in a list with multiple implementations, the first list will always be chosen by virtue of the code using index `[0]`. However, it should show the currently active implementation by using `[-1]`. This is probably unintended behavior. 

Without this change, it is impossible to use `user.help_list` with the `user.snippet` list that is contextually overridden based on programming language type. I would like to add a `help snip` command and that would depend on this.

