### PR TITLE
draft_talon_helpers: migrate away from deprecated settings usage

### DIFF
--- a/plugin/talon_draft_window/draft_talon_helpers.py
+++ b/plugin/talon_draft_window/draft_talon_helpers.py
@@ -18,19 +18,19 @@ title: Talon Draft
 """
 
 mod.tag("draft_window_showing", desc="Tag set when draft window showing")
-setting_theme = mod.setting(
+mod.setting(
     "draft_window_theme",
     type=str,
     default="dark",
     desc="Sets the main colors of the window, one of 'dark' or 'light'",
 )
-setting_label_size = mod.setting(
+mod.setting(
     "draft_window_label_size",
     type=int,
     default=20,
     desc="Sets the size of the word labels used in the draft window",
 )
-setting_label_color = mod.setting(
+mod.setting(
     "draft_window_label_color",
     type=str,
     default=None,
@@ -39,7 +39,7 @@ setting_label_color = mod.setting(
         "E.g. 00ff00 would be green"
     ),
 )
-setting_text_size = mod.setting(
+mod.setting(
     "draft_window_text_size",
     type=int,
     default=20,

--- a/plugin/talon_draft_window/draft_talon_helpers.py
+++ b/plugin/talon_draft_window/draft_talon_helpers.py
@@ -54,12 +54,12 @@ draft_manager = DraftManager()
 def _update_draft_style(*args):
     draft_manager.set_styling(
         **{
-            arg: setting.get()
+            arg: settings.get(setting)
             for setting, arg in (
-                (setting_theme, "theme"),
-                (setting_label_size, "label_size"),
-                (setting_label_color, "label_color"),
-                (setting_text_size, "text_size"),
+                ("user.draft_window_theme", "theme"),
+                ("user.draft_window_label_size", "label_size"),
+                ("user.draft_window_label_color", "label_color"),
+                ("user.draft_window_text_size", "text_size"),
             )
         }
     )


### PR DESCRIPTION
Fixed warning about using `setting.get()`
Changed to use `settings.get(setting_name)`

Closes #1473 
See also https://github.com/talonhub/community/pull/1351, https://github.com/talonhub/community/pull/1349