### PR TITLE
functions: remove unused `setting_` module variables

### DIFF
--- a/lang/tags/functions.py
+++ b/lang/tags/functions.py
@@ -32,16 +32,12 @@ def code_type(m) -> str:
     return m.code_type
 
 
-setting_private_function_formatter = mod.setting("code_private_function_formatter", str)
-setting_protected_function_formatter = mod.setting(
-    "code_protected_function_formatter", str
-)
-setting_public_function_formatter = mod.setting("code_public_function_formatter", str)
-setting_private_variable_formatter = mod.setting("code_private_variable_formatter", str)
-setting_protected_variable_formatter = mod.setting(
-    "code_protected_variable_formatter", str
-)
-setting_public_variable_formatter = mod.setting("code_public_variable_formatter", str)
+mod.setting("code_private_function_formatter", str)
+mod.setting("code_protected_function_formatter", str)
+mod.setting("code_public_function_formatter", str)
+mod.setting("code_private_variable_formatter", str)
+mod.setting("code_protected_variable_formatter", str)
+mod.setting("code_public_variable_formatter", str)
 
 
 @mod.action_class


### PR DESCRIPTION
A tiny cleanup in line with the recommendation I pushed to @CodesAway's  https://github.com/talonhub/community/pull/1474.

With the move to `settings.get()`, we should no longer assign settings to module-level variables, since it's no longer needed, and we don't want anyone to use them by mistake. These aren't being used, so let's just remove them.

This means you can now grep for `= mod.setting(` to search for old usages, and it comes up clean on main.

(To my surprise, this code was using `settings.get()` from the beginning when @wenkokke wrote it)