### PR TITLE
Fix bug where you couldn't select help context by index

### DIFF
--- a/core/help/help.py
+++ b/core/help/help.py
@@ -706,7 +706,7 @@ class Actions:
                             (current_context_page - 1)
                             * settings.get("user.help_max_contexts_per_page")
                             + index
-                        ]
+                        ][0]
                     ]
 
     def help_previous():


### PR DESCRIPTION
This broke in a recent update. 