### PR TITLE
Made default noise implementations noop

### DIFF
--- a/core/noise.py
+++ b/core/noise.py
@@ -16,6 +16,7 @@ class Actions:
         https://noise.talonvoice.com/static/previews/pop.mp3 for an
         example.
         """
+        actions.skip()
 
     def noise_trigger_hiss(active: bool):
         """
@@ -23,6 +24,7 @@ class Actions:
         https://noise.talonvoice.com/static/previews/hiss.mp3 for an
         example.
         """
+        actions.skip()
 
 
 def noise_trigger_hiss_debounce(active: bool):


### PR DESCRIPTION
Right now noises in the core directory is dependent on the implementation in of mouse that is in plugin. 

Fixes #1400