### PR TITLE
Don't use mimic when not using dragon

### DIFF
--- a/core/modes/modes_not_dragon.talon
+++ b/core/modes/modes_not_dragon.talon
@@ -38,4 +38,3 @@ not speech.engine: dragon
     user.help_hide()
     user.mouse_sleep()
     speech.disable()
-    user.engine_sleep()


### PR DESCRIPTION
Ideally I would remove `engine.py` but I don't really understand how this file interacts with dragon. I do know that using mimic is not needed for conformer. 

Related to #1503