### PR TITLE
Add more options for closing the mouse grid

### DIFF
--- a/core/mouse_grid/mouse_grid_open.talon
+++ b/core/mouse_grid/mouse_grid_open.talon
@@ -3,7 +3,7 @@ tag: user.mouse_grid_showing
 # Force prefixed numbers elsewhere in the config, which allows unprefixed use below
 tag(): user.prefixed_numbers
 <user.number_key>: user.grid_narrow(number_key)
-grid off: user.grid_close()
+grid (off | close | hide): user.grid_close()
 
 grid reset: user.grid_reset()
 


### PR DESCRIPTION
Currently you can only close the mouse grid with `grid off`, however this never felt very intuitive to me when learning to use the repository. I would often struggle to remember how to close it and this was annoying as it can be quite obstructive

Elsewhere in the repository to close something it is often either `<object> hide` such as `manager hide` or `<object> close` such as `help close`

As such this pull request adds the option to close the mouse grid with close and hide. 

But I'm not sure if this is just a personal opinion, happy to discuss in this pull request