### PR TITLE
Added navigation steps command

### DIFF
--- a/core/edit/edit.talon
+++ b/core/edit/edit.talon
@@ -13,13 +13,10 @@ next one: edit.find_next()
 scroll up: edit.page_up()
 scroll down: edit.page_down()
 
-go word left: edit.word_left()
-go word right: edit.word_right()
-
-go left: edit.left()
-go right: edit.right()
-go up: edit.up()
-go down: edit.down()
+# go left, go left left down, go 5 left 2 down
+# go word left, go 2 words right
+go <user.navigation_step>+:
+    user.perform_navigation_steps(navigation_step_list)
 
 go line start | head: edit.line_start()
 go line end | tail: edit.line_end()

--- a/core/edit/edit.talon
+++ b/core/edit/edit.talon
@@ -15,8 +15,7 @@ scroll down: edit.page_down()
 
 # go left, go left left down, go 5 left 2 down
 # go word left, go 2 words right
-go <user.navigation_step>+:
-    user.perform_navigation_steps(navigation_step_list)
+go <user.navigation_step>+: user.perform_navigation_steps(navigation_step_list)
 
 go line start | head: edit.line_start()
 go line end | tail: edit.line_end()

--- a/core/edit/edit_navigation_steps.py
+++ b/core/edit/edit_navigation_steps.py
@@ -1,0 +1,60 @@
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Callable, Literal
+from talon import Module, actions
+
+
+@dataclass
+class NavigationStep:
+    direction: Literal["up", "right", "down", "left"]
+    type: Literal["word", "character"]
+    count: int
+
+
+mod = Module()
+
+
+@mod.capture(rule="[<number_small>] [word | words] {user.arrow_key}")
+def navigation_step(m) -> NavigationStep:
+    type = "character"
+    count = 1
+
+    with suppress(IndexError):
+        if m[-2] in ["word", "words"]:
+            type = "word"
+
+    with suppress(AttributeError):
+        count = m.number_small
+
+    return NavigationStep(
+        direction=m.arrow_key,
+        type=type,
+        count=count,
+    )
+
+
+@mod.action_class
+class Actions:
+    def perform_navigation_steps(steps: list[NavigationStep]):
+        """Navigate by a series of steps"""
+        for step in steps:
+            match step.direction:
+                case "up":
+                    repeat_action(actions.edit.up, step.count)
+                case "down":
+                    repeat_action(actions.edit.down, step.count)
+                case "left":
+                    if step.type == "word":
+                        repeat_action(actions.edit.word_left, step.count)
+                    else:
+                        repeat_action(actions.edit.left, step.count)
+                case "right":
+                    if step.type == "word":
+                        repeat_action(actions.edit.word_right, step.count)
+                    else:
+                        repeat_action(actions.edit.right, step.count)
+
+
+def repeat_action(action: Callable, count: int):
+    for _ in range(count):
+        action()

--- a/core/edit/edit_navigation_steps.py
+++ b/core/edit/edit_navigation_steps.py
@@ -1,6 +1,7 @@
 from contextlib import suppress
 from dataclasses import dataclass
 from typing import Callable, Literal
+
 from talon import Module, actions
 
 

--- a/core/keys/keys.py
+++ b/core/keys/keys.py
@@ -1,4 +1,4 @@
-from talon import Context, Module, actions, app
+from talon import Context, Module, app
 
 from ..user_settings import get_list_from_csv
 
@@ -45,12 +45,6 @@ def modifiers(m) -> str:
 def arrow_key(m) -> str:
     "One directional arrow key"
     return m.arrow_key
-
-
-@mod.capture(rule="<self.arrow_key>+")
-def arrow_keys(m) -> str:
-    "One or more arrow keys separated by a space"
-    return str(m)
 
 
 @mod.capture(rule="{self.number_key}")
@@ -269,14 +263,3 @@ ctx.lists["self.special_key"] = special_keys
 ctx.lists["self.function_key"] = {
     f"F {name}": f"f{i}" for i, name in enumerate(f_digits, start=1)
 }
-
-
-@mod.action_class
-class Actions:
-    def move_cursor(s: str):
-        """Given a sequence of directions, eg. 'left left up', moves the cursor accordingly using edit.{left,right,up,down}."""
-        for d in s.split():
-            if d in ("left", "right", "up", "down"):
-                getattr(actions.edit, d)()
-            else:
-                raise RuntimeError(f"invalid arrow key: {d}")

--- a/core/keys/keys.talon
+++ b/core/keys/keys.talon
@@ -1,4 +1,3 @@
-go <user.arrow_keys>: user.move_cursor(arrow_keys)
 <user.letter>: key(letter)
 (ship | uppercase) <user.letters> [(lowercase | sunk)]:
     user.insert_formatted(letters, "ALL_CAPS")


### PR DESCRIPTION
Implemented new more powerful navigation grammar
* go left
* go left left down
* go 5 left 2 down
*  go word left
* go 2 words right
* go 5 left down down 4 words left

This is fully backwards compatible with the existing `go left`, `go word right` and `go left left down down` grammars. Only here combining them in a single (more powerful) command