### PR TITLE
Adds "go to tab" to Apple Terminal application.

### DIFF
--- a/apps/apple_terminal/apple_terminal.py
+++ b/apps/apple_terminal/apple_terminal.py
@@ -82,6 +82,7 @@ class UserActions:
         if number <= 9:
             actions.key(f"cmd-{number}")
 
+
 @ctx.action_class("app")
 class app_actions:
     # other tab functions should already be implemented in

--- a/apps/apple_terminal/apple_terminal.py
+++ b/apps/apple_terminal/apple_terminal.py
@@ -77,6 +77,10 @@ class UserActions:
     def file_manager_refresh_title():
         return
 
+    def tab_jump(number: int):
+        """Jumps to the specified tab. Cmd+1 switching be enabled in terminal settings to work properly."""
+        if number <= 9:
+            actions.key(f"cmd-{number}")
 
 @ctx.action_class("app")
 class app_actions:


### PR DESCRIPTION
This adds the "go to tab" command to the apple terminal application.

Relies on "Use #-1 through #-9 to switch tabs" being checked in application settings. (This is the default setting.)

It is possible to programmatically detect this using a shell command. I didn't do that because I don't know a lot of python and it adds complexity.

The setting is on
```bash
> defaults read com.apple.Terminal "Command1Through9SwitchesTabs" 
The domain/default pair of (com.apple.Terminal, Command1Through9SwitchesTabs) does not exist
> echo $!
847
```
The setting is off
```bash
> defaults read com.apple.Terminal "Command1Through9SwitchesTabs" 
0
> echo $!
0
```