### PR TITLE
Added setting for selected text timeout

### DIFF
--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -1,7 +1,14 @@
-from talon import Context, Module, actions, clip
+from talon import Context, Module, actions, clip, settings
 
 ctx = Context()
 mod = Module()
+
+mod.setting(
+    "selected_text_timeout",
+    type=float,
+    default=0.25,
+    desc="Time in seconds to wait for the clipboard to change when trying to get select the text",
+)
 
 END_OF_WORD_SYMBOLS = ".!?;:—_/\\|@#$%^&*()[]{}<>=+-~`"
 
@@ -9,7 +16,8 @@ END_OF_WORD_SYMBOLS = ".!?;:—_/\\|@#$%^&*()[]{}<>=+-~`"
 @ctx.action_class("edit")
 class EditActions:
     def selected_text() -> str:
-        with clip.capture() as s:
+        timeout = settings.get("user.selected_text_timeout")
+        with clip.capture(timeout) as s:
             actions.edit.copy()
         try:
             return s.text()

--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -7,7 +7,7 @@ mod.setting(
     "selected_text_timeout",
     type=float,
     default=0.25,
-    desc="Time in seconds to wait for the clipboard to change when trying to get select the text",
+    desc="Time in seconds to wait for the clipboard to change when trying to get selected text",
 )
 
 END_OF_WORD_SYMBOLS = ".!?;:—_/\\|@#$%^&*()[]{}<>=+-~`"

--- a/settings.talon
+++ b/settings.talon
@@ -80,6 +80,9 @@ settings():
     # Puts Talon into sleep mode if no commands are spoken for a defined period of time.
     # user.listening_timeout_minutes = 3
 
+    # Time in seconds to wait for the clipboard to change when trying to get selected text
+    # user.selected_text_timeout = 0.25
+
 # Uncomment to enable the curse yes/curse no commands (show/hide mouse cursor).
 # See issue #688 for more detail: https://github.com/talonhub/community/issues/688
 # tag(): user.mouse_cursor_commands_enable


### PR DESCRIPTION
The default time out for `clip.capture()` is 0.5s. You run into this every time you call `selected_text()` on an empty selection. I've been running with 0.1 for over a year with no problems. That might be a bit to aggressive for community, but 0.25 shouldn't be any problems. Just in case I added a setting so people with slower (or faster) machines can change this.

Fixes #1210