### PR TITLE
Catch and handle errors when closing draft editor

### DIFF
--- a/plugin/draft_editor/draft_editor.py
+++ b/plugin/draft_editor/draft_editor.py
@@ -105,7 +105,6 @@ def get_editor_app() -> ui.App:
 
 
 def close_editor(submit_draft: bool) -> None:
-    global last_draft
     remove_tag("user.draft_editor_active")
     actions.edit.select_all()
     selected_text = actions.edit.selected_text()

--- a/plugin/draft_editor/draft_editor.py
+++ b/plugin/draft_editor/draft_editor.py
@@ -105,14 +105,14 @@ def get_editor_app() -> ui.App:
 
 
 def close_editor(submit_draft: bool) -> None:
+    global last_draft
     remove_tag("user.draft_editor_active")
     actions.edit.select_all()
-    selected_text = actions.edit.selected_text()
+    if submit_draft:
+        last_draft = actions.edit.selected_text()
     actions.edit.delete()
     actions.app.tab_close()
     if submit_draft:
-        global last_draft
-        last_draft = selected_text
         try:
             actions.user.switcher_focus_window(original_window)
         except Exception:

--- a/plugin/draft_editor/draft_editor.py
+++ b/plugin/draft_editor/draft_editor.py
@@ -1,4 +1,4 @@
-from talon import Context, Module, actions, settings, ui, app
+from talon import Context, Module, actions, app, settings, ui
 
 mod = Module()
 mod.tag("draft_editor_active", "Indicates whether the draft editor has been activated")
@@ -82,11 +82,11 @@ class Actions:
 
     def draft_editor_submit():
         """Submit/save draft editor"""
-        close_editor(submit_draft = True)
+        close_editor(submit_draft=True)
 
     def draft_editor_discard():
         """Discard draft editor"""
-        close_editor(submit_draft = False)
+        close_editor(submit_draft=False)
 
     def draft_editor_paste_last():
         """Paste last submitted draft"""
@@ -103,6 +103,7 @@ def get_editor_app() -> ui.App:
 
     raise RuntimeError("Draft editor is not running")
 
+
 def close_editor(submit_draft: bool) -> None:
     global last_draft
     remove_tag("user.draft_editor_active")
@@ -116,7 +117,9 @@ def close_editor(submit_draft: bool) -> None:
         try:
             actions.user.switcher_focus_window(original_window)
         except Exception:
-            app.notify("Failed to focus on window to submit draft, manually focus on intended destination and use draft submit again")
+            app.notify(
+                "Failed to focus on window to submit draft, manually focus on intended destination and use draft submit again"
+            )
         else:
             actions.sleep("300ms")
             actions.user.paste(last_draft)

--- a/plugin/draft_editor/draft_editor.py
+++ b/plugin/draft_editor/draft_editor.py
@@ -1,4 +1,4 @@
-from talon import Context, Module, actions, app, settings, ui
+from talon import Context, Module, actions, settings, ui, app
 
 mod = Module()
 mod.tag("draft_editor_active", "Indicates whether the draft editor has been activated")
@@ -82,25 +82,11 @@ class Actions:
 
     def draft_editor_submit():
         """Submit/save draft editor"""
-        global last_draft
-        last_draft = close_editor()
-        try:
-            actions.user.switcher_focus_window(original_window)
-        except Exception:
-            app.notify(
-                "Failed to focus on window to submit draft, manually focus on intended destination and use draft submit again"
-            )
-        else:
-            actions.sleep("300ms")
-            actions.user.paste(last_draft)
+        close_editor(submit_draft = True)
 
     def draft_editor_discard():
         """Discard draft editor"""
-        close_editor()
-        try:
-            actions.user.switcher_focus_window(original_window)
-        except Exception:
-            app.notify("Failed to focus on previous window, leaving editor open")
+        close_editor(submit_draft = False)
 
     def draft_editor_paste_last():
         """Paste last submitted draft"""
@@ -117,12 +103,25 @@ def get_editor_app() -> ui.App:
 
     raise RuntimeError("Draft editor is not running")
 
-
-def close_editor() -> str:
+def close_editor(submit_draft: bool) -> None:
     global last_draft
     remove_tag("user.draft_editor_active")
     actions.edit.select_all()
     selected_text = actions.edit.selected_text()
     actions.edit.delete()
     actions.app.tab_close()
-    return selected_text
+    if submit_draft:
+        global last_draft
+        last_draft = selected_text
+        try:
+            actions.user.switcher_focus_window(original_window)
+        except Exception:
+            app.notify("Failed to focus on window to submit draft, manually focus on intended destination and use draft submit again")
+        else:
+            actions.sleep("300ms")
+            actions.user.paste(last_draft)
+    else:
+        try:
+            actions.user.switcher_focus_window(original_window)
+        except Exception:
+            app.notify("Failed to focus on previous window, leaving editor open")

--- a/plugin/draft_editor/draft_editor.py
+++ b/plugin/draft_editor/draft_editor.py
@@ -1,4 +1,4 @@
-from talon import Context, Module, actions, settings, ui, app
+from talon import Context, Module, actions, app, settings, ui
 
 mod = Module()
 mod.tag("draft_editor_active", "Indicates whether the draft editor has been activated")
@@ -87,11 +87,12 @@ class Actions:
         try:
             actions.user.switcher_focus_window(original_window)
         except Exception:
-            app.notify("Failed to focus on window to submit draft, manually focus on intended destination and use draft submit again")
+            app.notify(
+                "Failed to focus on window to submit draft, manually focus on intended destination and use draft submit again"
+            )
         else:
             actions.sleep("300ms")
             actions.user.paste(last_draft)
-
 
     def draft_editor_discard():
         """Discard draft editor"""
@@ -115,6 +116,7 @@ def get_editor_app() -> ui.App:
             return app
 
     raise RuntimeError("Draft editor is not running")
+
 
 def close_editor() -> str:
     global last_draft


### PR DESCRIPTION
Sometimes submitting drafts can fail as it cannot find the window to focus on to submit the draft. As it is currently that draft can then be lost.

These changes catches any errors when trying to focus on the previous window, and informs the user how to fix this. 
