### PR TITLE
Update edit identifier `cutToClipboard`

### DIFF
--- a/core/edit/edit_command.py
+++ b/core/edit/edit_command.py
@@ -18,8 +18,8 @@ compound_actions = {
     ("delete", "line"): actions.edit.delete_line,
     ("delete", "paragraph"): actions.edit.delete_paragraph,
     ("delete", "document"): actions.edit.delete_all,
-    # Cut
-    ("cut", "line"): actions.user.cut_line,
+    # Cut to clipboard
+    ("cutToClipboard", "line"): actions.user.cut_line,
 }
 
 


### PR DESCRIPTION
Update use the correct action identifier

Should match this file
https://github.com/talonhub/community/blob/bc88b144e69cf4afedb0e080bab3085e20365d69/core/edit/edit_command_actions.talon-list#L9

Without the correct identifier whenever someone says `"cut line"` they won't actually get the implementation of `user.cut_line()`