### PR TITLE
override peek implementation for libreoffice

### DIFF
--- a/apps/libreoffice/libreoffice.py
+++ b/apps/libreoffice/libreoffice.py
@@ -1,4 +1,5 @@
 from typing import Callable
+
 from talon import Context, Module, actions, settings
 
 mod = Module()
@@ -13,9 +14,10 @@ ctx.matches = r"""
 app: libreoffice
 """
 
+
 # Unlike most other applications, LibreOffice does not move the cursor to the
 # start/end of the selection when pressing left/right. Instead, it only moves
-# the cursor one step. 
+# the cursor one step.
 @ctx.action_class("user")
 class UserActions:
     def dictation_peek(left, right):
@@ -26,12 +28,12 @@ class UserActions:
             actions.edit.extend_word_left()
             actions.edit.extend_word_left()
             before = actions.edit.selected_text()
-            repeat_action(actions.edit.right,len(before))
+            repeat_action(actions.edit.right, len(before))
         if right:
             actions.edit.extend_word_right()
             actions.edit.extend_word_right()
             after = actions.edit.selected_text()
-            repeat_action(actions.edit.left,len(after))
+            repeat_action(actions.edit.left, len(after))
         return (before, after)
 
 

--- a/apps/libreoffice/libreoffice.py
+++ b/apps/libreoffice/libreoffice.py
@@ -1,0 +1,40 @@
+from typing import Callable
+from talon import Context, Module, actions, settings
+
+mod = Module()
+
+mod.apps.libreoffice = """
+os: linux
+and app.exe: soffice.bin
+"""
+
+ctx = Context()
+ctx.matches = r"""
+app: libreoffice
+"""
+
+# Unlike most other applications, LibreOffice does not move the cursor to the
+# start/end of the selection when pressing left/right. Instead, it only moves
+# the cursor one step. 
+@ctx.action_class("user")
+class UserActions:
+    def dictation_peek(left, right):
+        # clobber selection if it exists
+        actions.key("space backspace")
+        before, after = None, None
+        if left:
+            actions.edit.extend_word_left()
+            actions.edit.extend_word_left()
+            before = actions.edit.selected_text()
+            repeat_action(actions.edit.right,len(before))
+        if right:
+            actions.edit.extend_word_right()
+            actions.edit.extend_word_right()
+            after = actions.edit.selected_text()
+            repeat_action(actions.edit.left,len(after))
+        return (before, after)
+
+
+def repeat_action(action: Callable, count: int):
+    for _ in range(count):
+        action()


### PR DESCRIPTION
This only matches for `libreoffice` on Linux. I don't have access to Windows or Mac OS, so I don't know what `libreoffice` calls itself on those operating systems.