### PR TITLE
Enable readline and python tags in talon repl

### DIFF
--- a/apps/talon/talon_repl/talon_repl.py
+++ b/apps/talon/talon_repl/talon_repl.py
@@ -1,0 +1,19 @@
+from talon import Context, Module
+
+mod = Module()
+mod.apps.talon_repl = """
+win.title: /Talon - REPL/
+win.title: /.talon\/bin\/repl/
+"""
+
+ctx = Context()
+ctx.matches = r"""
+app: talon_repl
+not tag: user.code_language_forced
+"""
+
+
+@ctx.action_class("code")
+class CodeActions:
+    def language():
+        return "python"

--- a/apps/talon/talon_repl/talon_repl.talon
+++ b/apps/talon/talon_repl/talon_repl.talon
@@ -1,7 +1,7 @@
-win.title: /repl/
-win.title: /Talon - REPL/
+app: talon_repl
 -
 tag(): user.talon_python
+tag(): user.readline
 
 # uncomment user.talon_populate_lists tag to activate talon-specific lists of actions, scopes, modes etcetera.
 # Do not enable this tag with dragon, as it will be unusable.


### PR DESCRIPTION
Similar to #1451 this uses a context using not forced language to override `code.language` and enable python lang features inside the talon repl. It also makes the title matching more restricting, as this currently matches on anything with repl in the name, and there are many repls that aren't talon or python...

I also enable readline so that common navigation commands work inside. 