### PR TITLE
Add mission control to focus for app switcher

### DIFF
--- a/core/app_switcher/app_switcher.py
+++ b/core/app_switcher/app_switcher.py
@@ -367,6 +367,9 @@ class Actions:
         """Open a menu of running apps to switch to"""
         if app.platform == "windows":
             actions.key("alt-ctrl-tab")
+        elif app.platform == "mac":
+            # MacOS equivalent is "Mission Control"
+            actions.key("ctrl-up")
         else:
             print("Persistent Switcher Menu not supported on " + app.platform)
 


### PR DESCRIPTION
This adds functionality for application switching on MacOS.  The actual equivalent on MacOS is the Application Switcher (Command + Tab), but there is no built in way for this, to be persistent on screen with a single hot key.  The best alternative is Mission Control, which will show all of the open windows.