### PR TITLE
Added phrase enders list

### DIFF
--- a/core/text/phrase_ender.talon-list
+++ b/core/text/phrase_ender.talon-list
@@ -1,8 +1,4 @@
 list: user.phrase_ender
 -
 
-over:          ""
-space:         " "
-question:      "?"
-bang:          "!"
-slap:          "\n"
+over: ""

--- a/core/text/phrase_ender.talon-list
+++ b/core/text/phrase_ender.talon-list
@@ -1,0 +1,9 @@
+list: user.phrase_ender
+-
+
+over:          ""
+void:          " "
+step:          " "
+question:      "?"
+bang:          "!"
+slap:          "\n"

--- a/core/text/phrase_ender.talon-list
+++ b/core/text/phrase_ender.talon-list
@@ -2,8 +2,7 @@ list: user.phrase_ender
 -
 
 over:          ""
-void:          " "
-step:          " "
+space:         " "
 question:      "?"
 bang:          "!"
 slap:          "\n"

--- a/core/text/text.talon
+++ b/core/text/text.talon
@@ -6,7 +6,7 @@ phrase <user.text> {user.phrase_ender}:
     user.add_phrase_to_history(text)
     insert("{text}{phrase_ender}")
 {user.prose_formatter} <user.prose>$: user.insert_formatted(prose, prose_formatter)
-{user.prose_formatter} <user.prose> {user.phrase_ender}: 
+{user.prose_formatter} <user.prose> {user.phrase_ender}:
     user.insert_formatted(prose, prose_formatter)
     insert(phrase_ender)
 <user.format_code>+$: user.insert_many(format_code_list)

--- a/core/text/text.talon
+++ b/core/text/text.talon
@@ -6,7 +6,9 @@ phrase <user.text> {user.phrase_ender}:
     user.add_phrase_to_history(text)
     insert("{text}{phrase_ender}")
 {user.prose_formatter} <user.prose>$: user.insert_formatted(prose, prose_formatter)
-{user.prose_formatter} <user.prose> over: user.insert_formatted(prose, prose_formatter)
+{user.prose_formatter} <user.prose> {user.phrase_ender}: 
+    user.insert_formatted(prose, prose_formatter)
+    insert(phrase_ender)
 <user.format_code>+$: user.insert_many(format_code_list)
 <user.format_code>+ {user.phrase_ender}: 
     user.insert_many(format_code_list)

--- a/core/text/text.talon
+++ b/core/text/text.talon
@@ -2,13 +2,15 @@
 phrase <user.text>$:
     user.add_phrase_to_history(text)
     insert(text)
-phrase <user.text> over:
+phrase <user.text> {user.phrase_ender}:
     user.add_phrase_to_history(text)
-    insert(text)
+    insert("{text}{phrase_ender}")
 {user.prose_formatter} <user.prose>$: user.insert_formatted(prose, prose_formatter)
 {user.prose_formatter} <user.prose> over: user.insert_formatted(prose, prose_formatter)
 <user.format_code>+$: user.insert_many(format_code_list)
-<user.format_code>+ over: user.insert_many(format_code_list)
+<user.format_code>+ {user.phrase_ender}: 
+    user.insert_many(format_code_list)
+    insert(phrase_ender)
 <user.formatters> that: user.formatters_reformat_selection(user.formatters)
 {user.word_formatter} <user.word>: user.insert_formatted(word, word_formatter)
 <user.formatters> (pace | paste): user.insert_formatted(clip.text(), formatters)

--- a/core/text/text_and_dictation.py
+++ b/core/text/text_and_dictation.py
@@ -15,6 +15,7 @@ mod.setting(
 
 mod.list("prose_modifiers", desc="Modifiers that can be used within prose")
 mod.list("prose_snippets", desc="Snippets that can be used within prose")
+mod.list("phrase_ender", "List of commands that can be used to end a phrase")
 ctx = Context()
 # Maps spoken forms to DictationFormat method names (see DictationFormat below).
 ctx.lists["user.prose_modifiers"] = {


### PR DESCRIPTION
Instead of just `"over"`, adds a list of symbols that can be used to end/terminate a phrase. Also supports values for these phrases so you can end your phrase with a symbol that will be inserted. eg `"say hello there slap"` => `hello there\n`

This implementation is quite simple with the drawback that there is no synchronization between the spoken forms in this list and existing voice commands for adding these symbols. 

Slack reference
https://talonvoice.slack.com/archives/C9MHQ4AGP/p1723643676364569
