### PR TITLE
Skip non speakable abbreviation values

### DIFF
--- a/core/abbreviate/abbreviate.py
+++ b/core/abbreviate/abbreviate.py
@@ -454,7 +454,7 @@ abbreviations_list = get_list_from_csv(
     default=abbreviations,
 )
 
-# Matches letters and space. Talon accepts nothing else as a spoken form.
+# Matches letters and spaces, as currently, Talon doesn't accept other characters in spoken forms.
 PATTERN = re.compile(r"^[a-zA-Z ]+$")
 abbreviation_values = {
     v: v for v in abbreviations_list.values() if PATTERN.match(v) is not None

--- a/core/abbreviate/abbreviate.py
+++ b/core/abbreviate/abbreviate.py
@@ -1,4 +1,5 @@
 import re
+
 from talon import Context, Module
 
 from ..user_settings import get_list_from_csv

--- a/core/abbreviate/abbreviate.py
+++ b/core/abbreviate/abbreviate.py
@@ -1,3 +1,4 @@
+import re
 from talon import Context, Module
 
 from ..user_settings import get_list_from_csv
@@ -452,9 +453,15 @@ abbreviations_list = get_list_from_csv(
     default=abbreviations,
 )
 
+# Matches letters and space. Talon accepts nothing else as a spoken form.
+PATTERN = re.compile(r"^[a-zA-Z ]+$")
+abbreviation_values = {
+    v: v for v in abbreviations_list.values() if PATTERN.match(v) is not None
+}
+
 # Allows the abbreviated/short form to be used as spoken phrase. eg "brief app" -> app
 abbreviations_list_with_values = {
-    **{v: v for v in abbreviations_list.values()},
+    **abbreviation_values,
     **abbreviations_list,
 }
 


### PR DESCRIPTION
Today a user gets warnings in the Talon log if the abbreviation value is not speakable