### PR TITLE
Select final web area to avoid devtools

### DIFF
--- a/tags/browser/browser_mac.py
+++ b/tags/browser/browser_mac.py
@@ -27,7 +27,7 @@ class BrowserActions:
         except IndexError:
             return ""
         try:
-            web_area = window.element.children.find_one(AXRole="AXWebArea")
+            web_area = window.element.children.find(AXRole="AXWebArea")[-1]
             address = web_area.AXURL
         except (ui.UIErr, AttributeError):
             try:

--- a/tags/browser/browser_mac.py
+++ b/tags/browser/browser_mac.py
@@ -1,5 +1,4 @@
 from talon import Context, actions, app, mac, ui
-from talon.mac import applescript
 
 ctx = Context()
 ctx.matches = r"""
@@ -27,22 +26,37 @@ class BrowserActions:
         except IndexError:
             return ""
         try:
-            web_area = window.element.children.find(AXRole="AXWebArea")[-1]
-            address = web_area.AXURL
-        except (ui.UIErr, AttributeError):
-            try:
-                address = applescript.run(
-                    """
-                    tell application id "{bundle}"
-                        if not (exists (window 1)) then return ""
-                        return the URL of the active tab of the front window
-                    end tell""".format(
-                        bundle=actions.app.bundle()
-                    )
-                )
-            except mac.applescript.ApplescriptErr:
-                return actions.next()
-        return address
+            # for Firefox and Chromium-based browsers (if accessibility available)
+            addresses = [
+                web_area.AXURL for web_area in window.children.find(AXRole="AXWebArea")
+            ]
+            match len(addresses):
+                case 0:
+                    pass
+                case 1:
+                    return addresses[0]
+                case _:
+                    addresses = [
+                        a
+                        for a in addresses
+                        if not (
+                            a.startswith("devtools:")
+                            or a.startswith("about:devtools")
+                            or a.startswith("chrome://devtools/")
+                        )
+                    ]
+                    if len(addresses) == 1:
+                        return addresses[0]
+        except (ui.UIErr, AttributeError) as e:
+            pass
+        try:
+            # for Chromium-based browsers (if scripting available)
+            front_window = window.appscript()
+            if tab := getattr(front_window, "active_tab", None):
+                return tab.URL()
+            return ""
+        except:
+            return actions.next()
 
     def bookmark():
         actions.key("cmd-d")


### PR DESCRIPTION
On mac os, I was having an issue with `browser.host` which can be reproduced with the following steps.
1. put the following in a talon file:
```
browser.host: www.google.com
-
testing: app.notify("testing")
```
2. in firefox, open google.com
3. say "testing", verify you get the notification
4. open dev tools, focus another app, and then focused firefox again
5. say "testing", you will NOT get the notification 

It seems that in this scenario browser.host context matcher is no longer respected. I hunted down the issue to this line.

My change is probably pretty brittle, but at least works on mac (the only operating system where this code applies) chrome and firefox.

Some slack discussion took place here: https://talonvoice.slack.com/archives/C9MHQ4AGP/p1724030602939929