### PR TITLE
Convert keys to .talon-list where possible

### DIFF
--- a/core/keys/arrow_key.talon-list
+++ b/core/keys/arrow_key.talon-list
@@ -1,0 +1,6 @@
+list: user.arrow_key
+-
+down: down
+left: left
+right: right
+up: up

--- a/core/keys/function_key.talon-list
+++ b/core/keys/function_key.talon-list
@@ -20,7 +20,8 @@ f seventeen: f17
 f eighteen: f18
 f nineteen: f19
 f twenty: f20
-f twenty one: f21
-f twenty two: f22
-f twenty three: f23
-f twenty four: f24
+# these f keys are not supported by all platforms (eg Mac) and are disabled by default
+#f twenty one: f21
+#f twenty two: f22
+#f twenty three: f23
+#f twenty four: f24

--- a/core/keys/function_key.talon-list
+++ b/core/keys/function_key.talon-list
@@ -1,0 +1,26 @@
+list: user.function_key
+-
+f one: f1
+f two: f2
+f three: f3
+f four: f4
+f five: f5
+f six: f6
+f seven: f7
+f eight: f8
+f nine: f9
+f ten: f10
+f eleven: f11
+f twelve: f12
+f thirteen: f13
+f fourteen: f14
+f fifteen: f15
+f sixteen: f16
+f seventeen: f17
+f eighteen: f18
+f nineteen: f19
+f twenty: f20
+f twenty one: f21
+f twenty two: f22
+f twenty three: f23
+f twenty four: f24

--- a/core/keys/keypad_key.talon-list
+++ b/core/keys/keypad_key.talon-list
@@ -1,0 +1,19 @@
+list: user.keypad_key
+-
+key pad zero: keypad_0
+key pad one: keypad_1
+key pad two: keypad_2
+key pad three: keypad_3
+key pad four: keypad_4
+key pad five: keypad_5
+key pad six: keypad_6
+key pad seven: keypad_7
+key pad eight: keypad_8
+key pad nine: keypad_9
+key pad point: keypad_decimal
+key pad plus: keypad_plus
+key pad minus: keypad_minus
+key pad star: keypad_multiply
+key pad slash: keypad_divide
+key pad equals: keypad_equals
+key pad clear: keypad_clear

--- a/core/keys/keys.py
+++ b/core/keys/keys.py
@@ -201,4 +201,3 @@ symbol_key_words = {
 symbol_key_words.update(punctuation_words)
 ctx.lists["self.punctuation"] = punctuation_words
 ctx.lists["self.symbol_key"] = symbol_key_words
-

--- a/core/keys/keys.py
+++ b/core/keys/keys.py
@@ -8,7 +8,7 @@ mod.list("number_key", desc="All number keys")
 mod.list("modifier_key", desc="All modifier keys")
 mod.list("function_key", desc="All function keys")
 mod.list("special_key", desc="All special keys")
-mod.list("keypad_key", desc="all keypad keys ")
+mod.list("keypad_key", desc="All keypad keys")
 mod.list("punctuation", desc="words for inserting punctuation into text")
 
 

--- a/core/keys/keys.py
+++ b/core/keys/keys.py
@@ -1,11 +1,4 @@
-from talon import Context, Module, app
-
-from ..user_settings import get_list_from_csv
-
-# used for number keys & function keys respectively
-digits = "zero one two three four five six seven eight nine".split()
-f_digits = "one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty".split()
-
+from talon import Context, Module, actions, app
 
 mod = Module()
 mod.list("letter", desc="The spoken phonetic alphabet")
@@ -15,6 +8,7 @@ mod.list("number_key", desc="All number keys")
 mod.list("modifier_key", desc="All modifier keys")
 mod.list("function_key", desc="All function keys")
 mod.list("special_key", desc="All special keys")
+mod.list("keypad_key", desc="all keypad keys ")
 mod.list("punctuation", desc="words for inserting punctuation into text")
 
 
@@ -40,6 +34,12 @@ def arrow_keys(m) -> str:
 def number_key(m) -> str:
     "One number key"
     return m.number_key
+
+
+@mod.capture(rule="{self.keypad_key}")
+def keypad_key(m) -> str:
+    "One keypad key"
+    return m.keypad_key
 
 
 @mod.capture(rule="{self.letter}")
@@ -74,7 +74,7 @@ def any_alphanumeric_key(m) -> str:
 
 @mod.capture(
     rule="( <self.letter> | <self.number_key> | <self.symbol_key> "
-    "| <self.arrow_key> | <self.function_key> | <self.special_key> )"
+    "| <self.arrow_key> | <self.function_key> | <self.special_key> | <self.keypad_key>)"
 )
 def unmodified_key(m) -> str:
     "A single key with no modifiers"
@@ -104,17 +104,6 @@ def letters(m) -> str:
 
 
 ctx = Context()
-modifier_keys = {
-    # If you find 'alt' is often misrecognized, try using 'alter'.
-    "alt": "alt",  #'alter': 'alt',
-    "control": "ctrl",  #'troll':   'ctrl',
-    "shift": "shift",  #'sky':     'shift',
-    "super": "super",
-}
-if app.platform == "mac":
-    modifier_keys["command"] = "cmd"
-    modifier_keys["option"] = "alt"
-ctx.lists["self.modifier_key"] = modifier_keys
 
 # `punctuation_words` is for words you want available BOTH in dictation and as key names in command mode.
 # `symbol_key_words` is for key names that should be available in command mode, but NOT during dictation.
@@ -212,42 +201,4 @@ symbol_key_words = {
 symbol_key_words.update(punctuation_words)
 ctx.lists["self.punctuation"] = punctuation_words
 ctx.lists["self.symbol_key"] = symbol_key_words
-ctx.lists["self.number_key"] = {name: str(i) for i, name in enumerate(digits)}
-ctx.lists["self.arrow_key"] = {
-    "down": "down",
-    "left": "left",
-    "right": "right",
-    "up": "up",
-}
 
-simple_keys = [
-    "end",
-    "enter",
-    "escape",
-    "home",
-    "insert",
-    "pagedown",
-    "pageup",
-    "space",
-    "tab",
-]
-
-alternate_keys = {
-    "wipe": "backspace",
-    "delete": "backspace",
-    #'junk': 'backspace',
-    "forward delete": "delete",
-    "page up": "pageup",
-    "page down": "pagedown",
-}
-# mac apparently doesn't have the menu key.
-if app.platform in ("windows", "linux"):
-    alternate_keys["menu key"] = "menu"
-    alternate_keys["print screen"] = "printscr"
-
-special_keys = {k: k for k in simple_keys}
-special_keys.update(alternate_keys)
-ctx.lists["self.special_key"] = special_keys
-ctx.lists["self.function_key"] = {
-    f"F {name}": f"f{i}" for i, name in enumerate(f_digits, start=1)
-}

--- a/core/keys/letter.talon-list
+++ b/core/keys/letter.talon-list
@@ -1,6 +1,6 @@
 list: user.letter
 -
-# for common alternative spoken forms for letters, visit 
+# for common alternative spoken forms for letters, visit
 # https://talon.wiki/quickstart/improving_recognition_accuracy/#collected-alternatives-to-the-default-alphabet
 air: a
 bat: b

--- a/core/keys/letter.talon-list
+++ b/core/keys/letter.talon-list
@@ -1,5 +1,7 @@
 list: user.letter
 -
+# for common alternative spoken forms for letters, visit 
+# https://talon.wiki/quickstart/improving_recognition_accuracy/#collected-alternatives-to-the-default-alphabet
 air: a
 bat: b
 cap: c

--- a/core/keys/mac/modifier_key.talon-list
+++ b/core/keys/mac/modifier_key.talon-list
@@ -1,0 +1,9 @@
+list: user.modifier_key
+os: mac
+-
+alt: alt
+control: ctrl
+shift: shift
+super: cmd
+command: cmd
+option: alt

--- a/core/keys/mac/special_key.talon-list
+++ b/core/keys/mac/special_key.talon-list
@@ -1,0 +1,14 @@
+list: user.special_key
+os: mac
+-
+end: end
+home: home
+minus: minus
+enter: enter
+page down: pagedown
+page up: pageup
+escape: escape
+tab: tab
+wipe: backspace
+delete: backspace
+forward delete: delete

--- a/core/keys/number_key.talon-list
+++ b/core/keys/number_key.talon-list
@@ -1,0 +1,12 @@
+list: user.number_key
+-
+zero: 0
+one: 1
+two: 2
+three: 3
+four: 4
+five: 5
+six: 6
+seven: 7
+eight: 8
+nine: 9

--- a/core/keys/win/modifier_key.talon-list
+++ b/core/keys/win/modifier_key.talon-list
@@ -1,0 +1,11 @@
+list: user.modifier_key
+os: windows
+os: linux
+-
+alt: alt
+control: ctrl
+shift: shift
+# super is the windows key
+super: super
+command: ctrl
+option: alt

--- a/core/keys/win/special_key.talon-list
+++ b/core/keys/win/special_key.talon-list
@@ -1,0 +1,17 @@
+list: user.special_key
+os: windows
+os: linux
+-
+end: end
+home: home
+minus: minus
+enter: enter
+page down: pagedown
+page up: pageup
+escape: escape
+tab: tab
+wipe: backspace
+delete: backspace
+forward delete: delete
+menu key: menu
+print screen: printscr


### PR DESCRIPTION
- does not port punctuation_words or symbol_keys, as these are used by create spoken forms
- adds support for keypad keys