### PR TITLE
override edit.selected_text (preserve/restore selection after copy)

### DIFF
--- a/apps/emacs/emacs.py
+++ b/apps/emacs/emacs.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from talon import Context, Module, actions, settings
+from talon import Context, Module, actions, settings, clip
 
 mod = Module()
 mod.setting(
@@ -320,6 +320,16 @@ class EditActions:
     def find_previous():
         actions.key("ctrl-r")
 
+    def selected_text() -> str:
+        timeout = settings.get("user.selected_text_timeout")
+        with clip.capture(timeout) as s:
+            actions.edit.copy()
+            # this restores the selection after the copy
+            actions.user.emacs("exchange-point-and-mark")
+        try:
+            return s.text()
+        except clip.NoChange:
+            return ""
 
 @ctx.action_class("app")
 class AppActions:


### PR DESCRIPTION
For quite a while, have been annoyed by homophone selection (specifically `phones word`) not working in `emacs`. I finally tracked this down to the following issue: the call to `selected_text` inside of  ` user.homophones_show_selection` actually clears the selection. As a consequence, "choose" appends the selected homophone to the original word, instead of replacing it. 

Clearing the selection is the expected behavior when copying in `emacs`, but this changes `selected_text` to restore the selection after copying.

Note: This still requires enabling `delete-selection-mode`, but I would deem that acceptable when editing natural language text.

Context:
```
phones word:
    edit.select_word()
    user.homophones_show_selection()

choose <user.formatters> <number_small>:
    result = user.homophones_select(number_small)
    insert(user.formatted_text(result, formatters))
    user.homophones_hide()
```