### PR TITLE
Add tab clone command and improve file organization

### DIFF
--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -223,6 +223,14 @@ class UserActions:
     def split_window():
         actions.user.vscode("workbench.action.splitEditor")
 
+    def split_number(index: int):
+        """Navigates to a the specified split"""
+        if index < 9:
+            if is_mac:
+                actions.key(f"cmd-{index}")
+            else:
+                actions.key(f"ctrl-{index}")
+
     # splits.py support end
 
     # multiple_cursor.py support begin
@@ -254,6 +262,9 @@ class UserActions:
     def multi_cursor_skip_occurrence():
         actions.user.vscode("editor.action.moveSelectionToNextFindMatch")
 
+    # multiple_cursor.py support end
+
+    # tabs.py support begin
     def tab_jump(number: int):
         if number < 10:
             if is_mac:
@@ -273,16 +284,12 @@ class UserActions:
         else:
             actions.key("alt-0")
 
-    # splits.py support begin
-    def split_number(index: int):
-        """Navigates to a the specified split"""
-        if index < 9:
-            if is_mac:
-                actions.key(f"cmd-{index}")
-            else:
-                actions.key(f"ctrl-{index}")
-
-    # splits.py support end
+    def tab_duplicate():
+        # Duplicates the current tab into a new tab group
+        # vscode does not allow duplicate tabs in the same tab group, and so is implemented through splits
+        actions.user.split_window_vertically()
+    
+    # tabs.py support end
 
     # find_and_replace.py support begin
 

--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -224,7 +224,7 @@ class UserActions:
         actions.user.vscode("workbench.action.splitEditor")
 
     def split_number(index: int):
-        ordinal = [
+        supported_ordinals = [
             "First",
             "Second",
             "Third",
@@ -233,11 +233,10 @@ class UserActions:
             "Sixth",
             "Seventh",
             "Eighth",
-            "Last",
         ]
 
-        if 0 <= index < len(ordinal):
-            actions.user.vscode(f"workbench.action.focus{ordinal[index]}EditorGroup")
+        if 0 <= index - 1 < len(supported_ordinals):
+            actions.user.vscode(f"workbench.action.focus{supported_ordinals[index - 1]}EditorGroup")
 
     # splits.py support end
 

--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -288,7 +288,7 @@ class UserActions:
         # Duplicates the current tab into a new tab group
         # vscode does not allow duplicate tabs in the same tab group, and so is implemented through splits
         actions.user.split_window_vertically()
-    
+
     # tabs.py support end
 
     # find_and_replace.py support begin

--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -225,7 +225,15 @@ class UserActions:
 
     def split_number(index: int):
         ordinal = [
-            'First', 'Second', 'Third', 'Fourth', 'Fifth','Sixth','Seventh','Eighth','Last',
+            "First",
+            "Second",
+            "Third",
+            "Fourth",
+            "Fifth",
+            "Sixth",
+            "Seventh",
+            "Eighth",
+            "Last",
         ]
 
         if 0 <= index < len(ordinal):

--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -224,12 +224,12 @@ class UserActions:
         actions.user.vscode("workbench.action.splitEditor")
 
     def split_number(index: int):
-        """Navigates to a the specified split"""
-        if index < 9:
-            if is_mac:
-                actions.key(f"cmd-{index}")
-            else:
-                actions.key(f"ctrl-{index}")
+        ordinal = [
+            'First', 'Second', 'Third', 'Fourth', 'Fifth','Sixth','Seventh','Eighth','Last',
+        ]
+
+        if 0 <= index < len(ordinal):
+            actions.user.vscode(f"workbench.action.focus{ordinal}EditorGroup")
 
     # splits.py support end
 

--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -236,7 +236,9 @@ class UserActions:
         ]
 
         if 0 <= index - 1 < len(supported_ordinals):
-            actions.user.vscode(f"workbench.action.focus{supported_ordinals[index - 1]}EditorGroup")
+            actions.user.vscode(
+                f"workbench.action.focus{supported_ordinals[index - 1]}EditorGroup"
+            )
 
     # splits.py support end
 

--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -237,7 +237,7 @@ class UserActions:
         ]
 
         if 0 <= index < len(ordinal):
-            actions.user.vscode(f"workbench.action.focus{ordinal}EditorGroup")
+            actions.user.vscode(f"workbench.action.focus{ordinal[index]}EditorGroup")
 
     # splits.py support end
 


### PR DESCRIPTION
Implements the tab clone command in vscode. As you can't have two tabs of the same file open in the same tab group it splits the window vertically which clones the tab left and right.

Also cleans up the functions, grouping all of the splits,py, and tabs.py functions together