### PR TITLE
Add more per-platform keys in talon-lists.

### DIFF
--- a/core/keys/keypad_key.talon-list
+++ b/core/keys/keypad_key.talon-list
@@ -1,5 +1,6 @@
 list: user.keypad_key
 -
+
 key pad zero: keypad_0
 key pad one: keypad_1
 key pad two: keypad_2
@@ -17,3 +18,4 @@ key pad star: keypad_multiply
 key pad slash: keypad_divide
 key pad equals: keypad_equals
 key pad clear: keypad_clear
+key pad enter: keypad_enter

--- a/core/keys/keys.talon
+++ b/core/keys/keys.talon
@@ -4,6 +4,7 @@
 <user.symbol_key>: key(symbol_key)
 <user.function_key>: key(function_key)
 <user.special_key>: key(special_key)
+<user.keypad_key>: key(keypad_key)
 <user.modifiers> <user.unmodified_key>: key("{modifiers}-{unmodified_key}")
 # for key combos consisting only of modifiers, eg. `press super`.
 press <user.modifiers>: key(modifiers)

--- a/core/keys/mac/modifier_key.talon-list
+++ b/core/keys/mac/modifier_key.talon-list
@@ -1,9 +1,12 @@
 list: user.modifier_key
 os: mac
 -
+
 alt: alt
 control: ctrl
 shift: shift
 super: cmd
 command: cmd
 option: alt
+function: fn
+globe: fn

--- a/core/keys/mac/special_key.talon-list
+++ b/core/keys/mac/special_key.talon-list
@@ -5,12 +5,14 @@ os: mac
 end: end
 home: home
 minus: minus
-enter: enter
+return: return
+enter: keypad_enter
 page down: pagedown
 page up: pageup
 escape: escape
 space: space
 tab: tab
+insert: insert
 wipe: backspace
 delete: backspace
 forward delete: delete

--- a/core/keys/win/special_key.talon-list
+++ b/core/keys/win/special_key.talon-list
@@ -12,6 +12,7 @@ page up: pageup
 escape: escape
 space: space
 tab: tab
+insert: insert
 wipe: backspace
 delete: backspace
 forward delete: delete


### PR DESCRIPTION
All platforms:
- keypad_enter
- insert (inadvertently removed in #1554)
- Allow dictating keypad keys directly without "press"

Mac:
- "function"/"globe" for globe/fn modifier (increasingly used by the OS)
- "return" for return (as printed on Apple keyboards)
- "enter" for [keypad] enter

The only one I'm a bit worried about is the last one. It is correct per Apple's definitions but it's possible some users are used to saying "enter" (though it's not the correct name for the key) and will get unexpected behavior; in most Mac apps I've tried, Return and Enter behave identically.