### PR TITLE
Remove unprefixed numbers command

### DIFF
--- a/core/mouse_grid/mouse_grid_open.talon
+++ b/core/mouse_grid/mouse_grid_open.talon
@@ -1,7 +1,5 @@
 tag: user.mouse_grid_showing
 -
-# Force prefixed numbers elsewhere in the config, which allows unprefixed use below
-tag(): user.prefixed_numbers
 <user.number_key>: user.grid_narrow(number_key)
 grid (off | close | hide): user.grid_close()
 

--- a/core/numbers/numbers.py
+++ b/core/numbers/numbers.py
@@ -177,7 +177,7 @@ for ten in tens:
 number_small_map = {n: i for i, n in enumerate(number_small_list)}
 
 mod.list("number_small", desc="List of small numbers")
-mod.tag("prefixed_numbers", desc="Require prefix when saying a number")
+mod.tag("unprefixed_numbers", desc="Doesn't require prefix when saying a number")
 ctx.lists["self.number_small"] = number_small_map.keys()
 
 

--- a/core/numbers/numbers.py
+++ b/core/numbers/numbers.py
@@ -177,7 +177,7 @@ for ten in tens:
 number_small_map = {n: i for i, n in enumerate(number_small_list)}
 
 mod.list("number_small", desc="List of small numbers")
-mod.tag("unprefixed_numbers", desc="Doesn't require prefix when saying a number")
+mod.tag("unprefixed_numbers", desc="Dont require prefix when saying a number")
 ctx.lists["self.number_small"] = number_small_map.keys()
 
 

--- a/core/numbers/numbers_unprefixed.talon
+++ b/core/numbers/numbers_unprefixed.talon
@@ -1,5 +1,0 @@
-not tag: user.prefixed_numbers
--
-<user.number_string>:
-    insert("{number_string}")
-    user.deprecate_command("2024-01-27", "<number>", "numb <number>")

--- a/core/numbers/numbers_unprefixed.talon
+++ b/core/numbers/numbers_unprefixed.talon
@@ -1,4 +1,4 @@
 tag: user.unprefixed_numbers
 -
 
-numb <user.number_string>: "{number_string}"
+<user.number_string>: "{number_string}"

--- a/core/numbers/numbers_unprefixed.talon
+++ b/core/numbers/numbers_unprefixed.talon
@@ -1,0 +1,4 @@
+tag: user.unprefixed_numbers
+-
+
+numb <user.number_string>: "{number_string}"

--- a/settings.talon
+++ b/settings.talon
@@ -92,5 +92,5 @@ settings():
 
 # Uncomment the below to enable support for saying numbers without a prefix.
 # By default you need to say "numb one" to write "1". If you uncomment this,
-# you will can say "one" to write "1".
+# you can say "one" to write "1".
 # tag(): user.unprefixed_numbers

--- a/settings.talon
+++ b/settings.talon
@@ -89,9 +89,3 @@ settings():
 # Uncomment to enable the curse yes/curse no commands (show/hide mouse cursor).
 # See issue #688 for more detail: https://github.com/talonhub/community/issues/688
 # tag(): user.mouse_cursor_commands_enable
-
-# Uncomment the below to disable support for saying numbers without a prefix.
-# By default saying "one" would write "1", however many users find this behavior
-# prone to false positives. If you uncomment this, you will need to say
-# "numb one" to write "1". Note that this tag will eventually be activated by default
-# tag(): user.prefixed_numbers

--- a/settings.talon
+++ b/settings.talon
@@ -89,3 +89,8 @@ settings():
 # Uncomment to enable the curse yes/curse no commands (show/hide mouse cursor).
 # See issue #688 for more detail: https://github.com/talonhub/community/issues/688
 # tag(): user.mouse_cursor_commands_enable
+
+# Uncomment the below to enable support for saying numbers without a prefix.
+# By default you need to say "numb one" to write "1". If you uncomment this,
+# you will can say "one" to write "1".
+# tag(): user.unprefixed_numbers


### PR DESCRIPTION
This is a source of misrecognitions for new users. We have now had the deprecation message for nine months so I think it's fine to remove this.