### PR TITLE
Fix maximize split VSCode action

### DIFF
--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -191,7 +191,7 @@ class UserActions:
         actions.user.vscode("workbench.action.toggleEditorGroupLayout")
 
     def split_maximize():
-        actions.user.vscode("workbench.action.maximizeEditor")
+        actions.user.vscode("workbench.action.toggleMaximizeEditorGroup")
 
     def split_reset():
         actions.user.vscode("workbench.action.evenEditorWidths")


### PR DESCRIPTION
It looks like the vscode command has changed.