### PR TITLE
Swap go back and go forward commands on Mac.

### DIFF
--- a/core/navigation/navigation.py
+++ b/core/navigation/navigation.py
@@ -26,10 +26,10 @@ class BrowserActions:
 @ctx_mac.action_class("user")
 class MacActions:
     def go_back():
-        actions.key("cmd-]")
+        actions.key("cmd-[")
 
     def go_forward():
-        actions.key("cmd-[")
+        actions.key("cmd-]")
 
 
 @mod.action_class


### PR DESCRIPTION
Fixes #1563.
