### PR TITLE
Use registry.last_active_contexts instead of registry.active_contexts() in help system.

### DIFF
--- a/core/help/help.py
+++ b/core/help/help.py
@@ -69,7 +69,7 @@ def update_title():
             if selected_context is None:
                 refresh_context_command_map(show_enabled_contexts_only)
             else:
-                update_active_contexts_cache(registry.active_contexts())
+                update_active_contexts_cache(registry.last_active_contexts)
 
 
 @imgui.open(y=0)
@@ -396,7 +396,7 @@ overrides = {}
 
 
 def refresh_context_command_map(enabled_only=False):
-    active_contexts = registry.active_contexts()
+    active_contexts = registry.last_active_contexts
 
     local_context_map = {}
     local_display_name_to_context_name_map = {}
@@ -659,7 +659,7 @@ class Actions:
             refresh_context_command_map()
         else:
             selected_context_page = 1
-            update_active_contexts_cache(registry.active_contexts())
+            update_active_contexts_cache(registry.last_active_contexts)
 
         selected_context = m
         hide_all_help_guis()
@@ -761,7 +761,7 @@ class Actions:
             if selected_context is None:
                 refresh_context_command_map(show_enabled_contexts_only)
             else:
-                update_active_contexts_cache(registry.active_contexts())
+                update_active_contexts_cache(registry.last_active_contexts)
 
     def help_hide():
         """Hides the help"""


### PR DESCRIPTION
Per aegis, it is extra bad to be calling methods on the registry and upcoming Talon versions will break this usage.

Could likely remove our own cache now, but wanted to get this potential break-fix in first.
