### PR TITLE
Reimplement https://github.com/talonhub/community/pull/636

### DIFF
--- a/core/abbreviate/abbreviate.py
+++ b/core/abbreviate/abbreviate.py
@@ -448,6 +448,9 @@ abbreviations = {
     "work in progress": "wip",
 }
 
+@mod.capture(rule="brief {user.abbreviation}")
+def abbreviation(m) -> str:
+    return m.abbreviation
 
 @track_csv_list(
     "abbreviations.csv", headers=("Abbreviation", "Spoken Form"), default=abbreviations


### PR DESCRIPTION
Reimplement https://github.com/talonhub/community/pull/636

Notes:
- Adds abbreviation to word, as in the original. I'm not entirely sure this is desirable
- Since no maintainers use dragon, adds overrides for dragon to omit abbreviations from various captures per previous discussion. This can be tested with wav2letter by changing the context to not speech.engine: dragon