### PR TITLE
Fix MacOS "window" Command

### DIFF
--- a/apps/dock/dock.talon
+++ b/apps/dock/dock.talon
@@ -1,5 +1,5 @@
 os: mac
 -
 ^desktop$: user.dock_send_notification("com.apple.showdesktop.awake")
-^window$: user.dock_send_notification("com.apple.expose.front.awake")
+^window$: user.dock_send_notification("com.apple.expose.awake")
 ^launch pad$: user.dock_send_notification("com.apple.launchpad.toggle")


### PR DESCRIPTION
This fixes the mac "window" command, which is now `com.apple.expose.awake`