### PR TITLE
Remove unused modes

### DIFF
--- a/core/modes/modes.py
+++ b/core/modes/modes.py
@@ -5,9 +5,6 @@ ctx_sleep = Context()
 ctx_awake = Context()
 
 modes = {
-    "admin": "enable extra administration commands terminal (docker, etc)",
-    "debug": "a way to force debugger commands to be loaded",
-    "ida": "a way to force ida commands to be loaded",
     "presentation": "a more strict form of sleep where only a more strict wake up command works",
 }
 


### PR DESCRIPTION
None of these modes are used in community and even if they were they should have been tags instead.

Fixes #603