### PR TITLE
Update powershell to add option not to update the title

### DIFF
--- a/apps/powershell/README.md
+++ b/apps/powershell/README.md
@@ -11,3 +11,5 @@ function prompt {
   "$pwd" + '> '
 }
 ```
+
+Then you can set the setting `user.powershell_always_refresh_title` to false.

--- a/apps/powershell/README.md
+++ b/apps/powershell/README.md
@@ -1,0 +1,13 @@
+# Powershell
+
+By default the windows powershell does not display the current address in the title. To fix this add a prompt function to the powershell profile file. If the powershell profile file doesn't exist then create it.
+
+To find the profile file run `$profile` in windows powershell.
+
+The prompt function to add:
+```
+function prompt {
+  $Host.UI.RawUI.WindowTitle = 'Windows PowerShell: ' +  $(get-location)
+  "$pwd" + '> '
+}
+```

--- a/apps/powershell/powershell_win.py
+++ b/apps/powershell/powershell_win.py
@@ -36,7 +36,7 @@ class UserActions:
     def file_manager_open_parent():
         actions.insert("cd ..")
         actions.key("enter")
-        if settings.get("user.powershell_auto_refresh_title"):
+        if settings.get("user.powershell_always_refresh_title"):
             actions.user.file_manager_refresh_title()
 
     def file_manager_current_path():
@@ -54,7 +54,7 @@ class UserActions:
         """opens the directory that's already visible in the view"""
         actions.insert(f'cd "{path}"')
         actions.key("enter")
-        if settings.get("user.powershell_auto_refresh_title"):
+        if settings.get("user.powershell_always_refresh_title"):
             actions.user.file_manager_refresh_title()
 
     def file_manager_select_directory(path: str):

--- a/apps/powershell/powershell_win.py
+++ b/apps/powershell/powershell_win.py
@@ -1,4 +1,4 @@
-from talon import Context, Module, actions, ui
+from talon import Context, Module, actions, ui, settings
 
 ctx = Context()
 mod = Module()
@@ -10,6 +10,13 @@ and win.title: /PowerShell/
 
 directories_to_remap = {}
 directories_to_exclude = {}
+
+mod.setting(
+    "powershell_always_refresh_title",
+    type=bool,
+    default=True,
+    desc="If the title is refreshed after every directory move",
+)
 
 
 @ctx.action_class("edit")
@@ -29,7 +36,8 @@ class UserActions:
     def file_manager_open_parent():
         actions.insert("cd ..")
         actions.key("enter")
-        actions.user.file_manager_refresh_title()
+        if settings.get("user.powershell_auto_refresh_title"):
+            actions.user.file_manager_refresh_title()
 
     def file_manager_current_path():
         path = ui.active_window().title
@@ -46,7 +54,8 @@ class UserActions:
         """opens the directory that's already visible in the view"""
         actions.insert(f'cd "{path}"')
         actions.key("enter")
-        actions.user.file_manager_refresh_title()
+        if settings.get("user.powershell_auto_refresh_title"):
+            actions.user.file_manager_refresh_title()
 
     def file_manager_select_directory(path: str):
         """selects the directory"""
@@ -58,8 +67,8 @@ class UserActions:
 
     def file_manager_open_file(path: str):
         """opens the file"""
-        actions.insert(path)
-        # actions.key("enter")
+        actions.insert(f'./"{path}"')
+        actions.key("enter")
 
     def file_manager_select_file(path: str):
         """selects the file"""

--- a/apps/powershell/powershell_win.talon
+++ b/apps/powershell/powershell_win.talon
@@ -14,3 +14,5 @@ tag(): user.generic_windows_shell
 tag(): user.git
 tag(): user.anaconda
 # tag(): user.kubectl
+
+tag(): user.file_manager


### PR DESCRIPTION
Currently when using powershell the title is forced to be updated after every directory change automatically
This is updated by inserting a command into powershell which updates the title, which clutters your terminal quite quickly.

The better solution is that the user updates their powershell prompt function so that this is done automatically, and then turn off the forced title refresh.

This pull request adds the talon setting to turn off the automatic forced title refresh, and adds a readme on how to do this.

Additionally I've changed open file to actually automatically open the file. If the user just wants to insert the string of the file they can already use select file command. 

I'm not sure if it's best to add the powershell specific readme file or add the documentation in the project readme, or elsewhere, so that can move.