### PR TITLE
remove redundant `proud <user.word>` command 

### DIFF
--- a/core/text/text.talon
+++ b/core/text/text.talon
@@ -19,7 +19,6 @@ phrase <user.text> {user.phrase_ender}:
 word <user.word>:
     user.add_phrase_to_history(word)
     insert(word)
-proud <user.word>: user.insert_formatted(word, "CAPITALIZE_FIRST_WORD")
 recent list: user.toggle_phrase_history()
 recent close: user.phrase_history_hide()
 recent repeat <number_small>:


### PR DESCRIPTION
remove `proud <user.word>` command due to redundancy from `{user.word…_formatter} <user.word>` command