### PR TITLE
Fix select/copy/cut way left/right

### DIFF
--- a/core/edit/edit_command_modifiers.py
+++ b/core/edit/edit_command_modifiers.py
@@ -22,8 +22,8 @@ modifier_callbacks: dict[str, Callable] = {
     "paragraph": actions.edit.select_paragraph,
     "word": actions.edit.select_word,
     "line": actions.edit.select_line,
-    "lineEnd": actions.user.select_line_end,
-    "lineStart": actions.user.select_line_start,
+    "lineEnd": actions.edit.extend_line_end,
+    "lineStart": actions.edit.extend_line_start,
     "fileStart": actions.edit.extend_file_start,
     "fileEnd": actions.edit.extend_file_end,
 }


### PR DESCRIPTION
Currently edit modifier "way left" and "way right" uses actions.user.select_line_start/end

This action based upon it's comment description should be the same as actions.edit.extend_line_start/end but they have different behaviour.

Behaviour when using the current user action: before doing an extend line action it does a edit.left action, leading to a different selection than intended.

Prior to the move to the compound edit command `select way left` was using the actions.edit.extend_line_ action

I'm also not sure if the older action is actually necessary when we have the edit versions?