### PR TITLE
Remove dependency on `talon_plugins`

### DIFF
--- a/BREAKING_CHANGES.txt
+++ b/BREAKING_CHANGES.txt
@@ -7,6 +7,7 @@ and when the change was applied given the delay between changes being
 submitted and the time they were reviewed and merged.
 
 ---
+* 2024-12-26 Deprecated action `user.zoom_close` in favor of `tracking.zoom_cancel`.
 * 2024-11-24 Deprecated a bunch of symbol commands to insert delimited pairs
   ("", '', []) in favor of the new `delimiter_pair` Talon list file.
 * 2024-09-07 Removed `get_list_from_csv` from `user_settings.py`. Please

--- a/core/deprecations.py
+++ b/core/deprecations.py
@@ -164,7 +164,8 @@ class Actions:
     def deprecate_action(time_deprecated: str, name: str, replacement: str = ""):
         """
         Notify the user that the given action is deprecated and should
-        not be used into the future.
+        not be used into the future; the action `replacement` should be used
+        instead.
         """
 
         id = f"action.{name}.{time_deprecated}"

--- a/core/deprecations.py
+++ b/core/deprecations.py
@@ -161,7 +161,7 @@ class Actions:
         )
         warnings.warn(msg, DeprecationWarning, stacklevel=3)
 
-    def deprecate_action(time_deprecated: str, name: str):
+    def deprecate_action(time_deprecated: str, name: str, replacement: str = ""):
         """
         Notify the user that the given action is deprecated and should
         not be used into the future.
@@ -170,9 +170,11 @@ class Actions:
         id = f"action.{name}.{time_deprecated}"
 
         deprecate_notify(id, f"The `{name}` action is deprecated. See log for more.")
+        replacement_msg = f' Instead, use: "{replacement}".' if replacement else ""
 
         msg = (
             f"The `{name}` action is deprecated since {time_deprecated}."
+            f"{replacement_msg}"
             f' See {os.path.join(REPO_DIR, "BREAKING_CHANGES.txt")}'
             f"{calculate_rule_info()}"
         )

--- a/plugin/mouse/mouse.py
+++ b/plugin/mouse/mouse.py
@@ -37,7 +37,11 @@ mod.setting(
 class Actions:
     def zoom_close():
         """Closes an in-progress zoom. Talon will move the cursor position but not click."""
-        actions.user.deprecate_action("2024-12-26", "user.zoom_close")
+        actions.user.deprecate_action(
+            "2024-12-26",
+            "user.zoom_close",
+            "tracking.zoom_cancel",
+        )
 
     def mouse_wake():
         """Enable control mouse, zoom mouse, and disables cursor"""

--- a/plugin/mouse/mouse.py
+++ b/plugin/mouse/mouse.py
@@ -42,6 +42,7 @@ class Actions:
             "user.zoom_close",
             "tracking.zoom_cancel",
         )
+        actions.tracking.zoom_cancel()
 
     def mouse_wake():
         """Enable control mouse, zoom mouse, and disables cursor"""

--- a/plugin/mouse/mouse.py
+++ b/plugin/mouse/mouse.py
@@ -1,5 +1,4 @@
 from talon import Context, Module, actions, ctrl, settings, ui
-from talon_plugins import eye_zoom_mouse
 
 mod = Module()
 ctx = Context()
@@ -38,8 +37,7 @@ mod.setting(
 class Actions:
     def zoom_close():
         """Closes an in-progress zoom. Talon will move the cursor position but not click."""
-        if eye_zoom_mouse.zoom_mouse.state == eye_zoom_mouse.STATE_OVERLAY:
-            actions.tracking.zoom_cancel()
+        actions.user.deprecate_action("2024-12-26", "user.zoom_close")
 
     def mouse_wake():
         """Enable control mouse, zoom mouse, and disables cursor"""

--- a/plugin/mouse/mouse.talon
+++ b/plugin/mouse/mouse.talon
@@ -1,11 +1,11 @@
-control mouse: tracking.control_toggle()
-control off: user.mouse_sleep()
-zoom mouse: tracking.control_zoom_toggle()
-camera overlay: tracking.control_debug_toggle()
-run calibration: tracking.calibrate()
+control mouse:              tracking.control_toggle()
+control off:                user.mouse_sleep()
+zoom mouse:                 tracking.control_zoom_toggle()
+camera overlay:             tracking.control_debug_toggle()
+run calibration:            tracking.calibrate()
 touch:
     # close zoom if open
-    user.zoom_close()
+    tracking.zoom_cancel()
     mouse_click(0)
     # close the mouse grid if open
     user.grid_close()
@@ -15,14 +15,14 @@ touch:
 
 righty:
     # close zoom if open
-    user.zoom_close()
+    tracking.zoom_cancel()
     mouse_click(1)
     # close the mouse grid if open
     user.grid_close()
 
 mid click:
     # close zoom if open
-    user.zoom_close()
+    tracking.zoom_cancel()
     mouse_click(2)
     # close the mouse grid
     user.grid_close()
@@ -36,7 +36,7 @@ mid click:
 #super = windows key
 <user.modifiers> touch:
     # close zoom if open
-    user.zoom_close()
+    tracking.zoom_cancel()
     key("{modifiers}:down")
     mouse_click(0)
     key("{modifiers}:up")
@@ -44,7 +44,7 @@ mid click:
     user.grid_close()
 <user.modifiers> righty:
     # close zoom if open
-    user.zoom_close()
+    tracking.zoom_cancel()
     key("{modifiers}:down")
     mouse_click(1)
     key("{modifiers}:up")
@@ -52,14 +52,14 @@ mid click:
     user.grid_close()
 (dub click | duke):
     # close zoom if open
-    user.zoom_close()
+    tracking.zoom_cancel()
     mouse_click()
     mouse_click()
     # close the mouse grid
     user.grid_close()
 (trip click | trip lick):
     # close zoom if open
-    user.zoom_close()
+    tracking.zoom_cancel()
     mouse_click()
     mouse_click()
     mouse_click()
@@ -67,70 +67,70 @@ mid click:
     user.grid_close()
 left drag | drag | drag start:
     # close zoom if open
-    user.zoom_close()
+    tracking.zoom_cancel()
     user.mouse_drag(0)
     # close the mouse grid
     user.grid_close()
 right drag | righty drag:
     # close zoom if open
-    user.zoom_close()
+    tracking.zoom_cancel()
     user.mouse_drag(1)
     # close the mouse grid
     user.grid_close()
-end drag | drag end: user.mouse_drag_end()
-wheel down: user.mouse_scroll_down()
+end drag | drag end:        user.mouse_drag_end()
+wheel down:                 user.mouse_scroll_down()
 wheel down here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_down()
-wheel tiny [down]: user.mouse_scroll_down(0.2)
+wheel tiny [down]:          user.mouse_scroll_down(0.2)
 wheel tiny [down] here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_down(0.2)
-wheel downer: user.mouse_scroll_down_continuous()
+wheel downer:               user.mouse_scroll_down_continuous()
 wheel downer here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_down_continuous()
-wheel up: user.mouse_scroll_up()
+wheel up:                   user.mouse_scroll_up()
 wheel up here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_up()
-wheel tiny up: user.mouse_scroll_up(0.2)
+wheel tiny up:              user.mouse_scroll_up(0.2)
 wheel tiny up here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_up(0.2)
-wheel upper: user.mouse_scroll_up_continuous()
+wheel upper:                user.mouse_scroll_up_continuous()
 wheel upper here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_up_continuous()
-wheel gaze: user.mouse_gaze_scroll()
+wheel gaze:                 user.mouse_gaze_scroll()
 wheel gaze here:
     user.mouse_move_center_active_window()
     user.mouse_gaze_scroll()
-wheel stop: user.mouse_scroll_stop()
+wheel stop:                 user.mouse_scroll_stop()
 wheel stop here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_stop()
-wheel left: user.mouse_scroll_left()
+wheel left:                 user.mouse_scroll_left()
 wheel left here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_left()
-wheel tiny left: user.mouse_scroll_left(0.5)
+wheel tiny left:            user.mouse_scroll_left(0.5)
 wheel tiny left here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_left(0.5)
-wheel right: user.mouse_scroll_right()
+wheel right:                user.mouse_scroll_right()
 wheel right here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_right()
-wheel tiny right: user.mouse_scroll_right(0.5)
+wheel tiny right:           user.mouse_scroll_right(0.5)
 wheel tiny right here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_right(0.5)
-copy mouse position: user.copy_mouse_position()
+copy mouse position:        user.copy_mouse_position()
 curse no:
     # Command added 2021-12-13, can remove after 2022-06-01
     app.notify("Please activate the user.mouse_cursor_commands_enable tag to enable this command")
 
 # To scroll with a hiss sound, set mouse_enable_hiss_scroll to true in settings.talon
-mouse hiss up: user.hiss_scroll_up()
-mouse hiss down: user.hiss_scroll_down()
+mouse hiss up:              user.hiss_scroll_up()
+mouse hiss down:            user.hiss_scroll_down()

--- a/plugin/mouse/mouse.talon
+++ b/plugin/mouse/mouse.talon
@@ -1,8 +1,8 @@
-control mouse:              tracking.control_toggle()
-control off:                user.mouse_sleep()
-zoom mouse:                 tracking.control_zoom_toggle()
-camera overlay:             tracking.control_debug_toggle()
-run calibration:            tracking.calibrate()
+control mouse: tracking.control_toggle()
+control off: user.mouse_sleep()
+zoom mouse: tracking.control_zoom_toggle()
+camera overlay: tracking.control_debug_toggle()
+run calibration: tracking.calibrate()
 touch:
     # close zoom if open
     tracking.zoom_cancel()
@@ -77,60 +77,60 @@ right drag | righty drag:
     user.mouse_drag(1)
     # close the mouse grid
     user.grid_close()
-end drag | drag end:        user.mouse_drag_end()
-wheel down:                 user.mouse_scroll_down()
+end drag | drag end: user.mouse_drag_end()
+wheel down: user.mouse_scroll_down()
 wheel down here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_down()
-wheel tiny [down]:          user.mouse_scroll_down(0.2)
+wheel tiny [down]: user.mouse_scroll_down(0.2)
 wheel tiny [down] here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_down(0.2)
-wheel downer:               user.mouse_scroll_down_continuous()
+wheel downer: user.mouse_scroll_down_continuous()
 wheel downer here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_down_continuous()
-wheel up:                   user.mouse_scroll_up()
+wheel up: user.mouse_scroll_up()
 wheel up here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_up()
-wheel tiny up:              user.mouse_scroll_up(0.2)
+wheel tiny up: user.mouse_scroll_up(0.2)
 wheel tiny up here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_up(0.2)
-wheel upper:                user.mouse_scroll_up_continuous()
+wheel upper: user.mouse_scroll_up_continuous()
 wheel upper here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_up_continuous()
-wheel gaze:                 user.mouse_gaze_scroll()
+wheel gaze: user.mouse_gaze_scroll()
 wheel gaze here:
     user.mouse_move_center_active_window()
     user.mouse_gaze_scroll()
-wheel stop:                 user.mouse_scroll_stop()
+wheel stop: user.mouse_scroll_stop()
 wheel stop here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_stop()
-wheel left:                 user.mouse_scroll_left()
+wheel left: user.mouse_scroll_left()
 wheel left here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_left()
-wheel tiny left:            user.mouse_scroll_left(0.5)
+wheel tiny left: user.mouse_scroll_left(0.5)
 wheel tiny left here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_left(0.5)
-wheel right:                user.mouse_scroll_right()
+wheel right: user.mouse_scroll_right()
 wheel right here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_right()
-wheel tiny right:           user.mouse_scroll_right(0.5)
+wheel tiny right: user.mouse_scroll_right(0.5)
 wheel tiny right here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_right(0.5)
-copy mouse position:        user.copy_mouse_position()
+copy mouse position: user.copy_mouse_position()
 curse no:
     # Command added 2021-12-13, can remove after 2022-06-01
     app.notify("Please activate the user.mouse_cursor_commands_enable tag to enable this command")
 
 # To scroll with a hiss sound, set mouse_enable_hiss_scroll to true in settings.talon
-mouse hiss up:              user.hiss_scroll_up()
-mouse hiss down:            user.hiss_scroll_down()
+mouse hiss up: user.hiss_scroll_up()
+mouse hiss down: user.hiss_scroll_down()

--- a/plugin/mouse/mouse_scroll.py
+++ b/plugin/mouse/mouse_scroll.py
@@ -2,7 +2,6 @@ import time
 from typing import Literal
 
 from talon import Context, Module, actions, app, cron, ctrl, imgui, settings, ui
-from talon_plugins import eye_zoom_mouse
 
 continuous_scroll_mode = ""
 scroll_job = None
@@ -96,9 +95,6 @@ class Actions:
         """Starts gaze scroll"""
         global gaze_job, continuous_scroll_mode, control_mouse_forced
 
-        if eye_zoom_mouse.zoom_mouse.state != eye_zoom_mouse.STATE_IDLE:
-            return
-
         continuous_scroll_mode = "gaze scroll"
         gaze_job = cron.interval("16ms", scroll_gaze_helper)
 
@@ -168,9 +164,6 @@ class UserActions:
 
 def mouse_scroll_continuous(new_scroll_dir: Literal[-1, 1]):
     global scroll_job, scroll_dir, scroll_start_ts, continuous_scroll_mode
-
-    if eye_zoom_mouse.zoom_mouse.state != eye_zoom_mouse.STATE_IDLE:
-        return
 
     if scroll_job:
         # Issuing a scroll in the same direction aborts scrolling


### PR DESCRIPTION
`talon_plugins` has been removed in the latest beta. As far as I know there is no replacement to check if we are zoomed in or not.

Fixes https://github.com/talonhub/community/issues/1637