### PR TITLE
Fix exception type error

### DIFF
--- a/apps/jetbrains/jetbrains.py
+++ b/apps/jetbrains/jetbrains.py
@@ -143,7 +143,7 @@ class Actions:
                     send_idea_command(cmd.strip())
                     actions.sleep(0.1)
         except Exception as e:
-            app.notify(e)
+            app.notify(str(e))
             raise
 
     def idea_grab(times: int):


### PR DESCRIPTION
Fixes this:

```
2025-01-06 13:35:35.631 ERROR     9:            talon\scripting\talon_script.py:721| 
    8:            talon\scripting\talon_script.py:314| 
    7:                 talon\scripting\actions.py:88 | 
    6: user\community\apps\jetbrains\jetbrains.py:171| actions.user.idea("action NextTab")
    5:                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    4:                 talon\scripting\actions.py:88 | 
    3: user\community\apps\jetbrains\jetbrains.py:146| app.notify(e)
    2:                                                 ^^^^^^^^^^^^^
    1:                               talon\app.py:69 | 
TypeError: argument 'title': 'FileNotFoundError' object cannot be converted to 'PyString'

[The below error was raised while handling the above exception(s)]
```