### PR TITLE
Avoid race reading user.draft_editor setting at startup.

### DIFF
--- a/plugin/draft_editor/draft_editor.py
+++ b/plugin/draft_editor/draft_editor.py
@@ -58,10 +58,16 @@ def handle_app_activate(app):
         remove_tag("user.draft_editor_app_focused")
 
 
-ui.register("app_launch", handle_app_running)
-ui.register("app_close", handle_app_running)
-ui.register("app_activate", handle_app_activate)
+def on_ready():
+    ui.register("app_launch", handle_app_running)
+    ui.register("app_close", handle_app_running)
+    ui.register("app_activate", handle_app_activate)
 
+    handle_app_running(None)
+    handle_app_activate(ui.active_app())
+
+
+app.register("ready", on_ready)
 
 original_window = None
 


### PR DESCRIPTION
Current Talon beta raises an exception rather than returning `None` if you try to read a setting that isn't declared yet. This is intentional behavior — it exposes bugs like this one.

Also fixes `user.draft_editor*` tags not being set at startup.
