### PR TITLE
Revert vscode clipboard actions from #1677

### DIFF
--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -96,18 +96,6 @@ class CodeActions:
 
 @ctx.action_class("edit")
 class EditActions:
-    def undo():
-        actions.user.vscode("undo")
-
-    def redo():
-        actions.user.vscode("redo")
-
-    def copy():
-        actions.user.vscode("editor.action.clipboardCopyAction")
-
-    def paste():
-        actions.user.vscode("editor.action.clipboardPasteAction")
-
     # talon edit actions
     def indent_more():
         actions.user.vscode("editor.action.indentLines")


### PR DESCRIPTION
Reverts #1677

These actions doesn't work in all scenarios. eg a save dialog.
