### PR TITLE
Update gitignore match rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ __pycache__
 # Locally generated
 /settings
 .vscode/settings.json
-.DS_Store
-.bak
+*.DS_Store
+*.bak

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ __pycache__
 # Locally generated
 /settings
 .vscode/settings.json
-*.DS_Store
+.DS_Store
 *.bak


### PR DESCRIPTION
As it is currently written, the `.gitignore` file does not properly ignore `.bak`s. It also seems to not properly ignore `.DS_Store`s. Here I add the wildcard character to these patterns to make sure they are correctly matched against. 