### PR TITLE
Fix missing language definitions for snippets

### DIFF
--- a/core/modes/code_languages.py
+++ b/core/modes/code_languages.py
@@ -20,7 +20,6 @@ code_languages = [
     Language("batch", "batch", ["bat"]),
     Language("c", "see", ["c", "h"]),
     # Language("cmake", "see make", ["cmake"]),
-    # Language("cplusplus", "see plus plus", ["cpp", "hpp"]),
     Language("csharp", "see sharp", ["cs"]),
     Language("css", "c s s", ["css"]),
     # Language("elisp", "elisp", ["el"]),
@@ -28,12 +27,9 @@ code_languages = [
     # Language("elm", "elm", ["elm"]),
     Language("gdb", "g d b", ["gdb"]),
     Language("go", ["go lang", "go language"], ["go"]),
-    # html doesn't actually have a language mode, but we do have snippets.
-    Language("html", "html", ["html"]),
     Language("java", "java", ["java"]),
     Language("javascript", "java script", ["js"]),
     Language("javascriptreact", "java script react", ["jsx"]),
-    # Language("json", "json", ["json"]),
     # Language("jsonl", "json lines", ["jsonl"]),
     Language("kotlin", "kotlin", ["kt"]),
     Language("lua", "lua", ["lua"]),
@@ -60,6 +56,12 @@ code_languages = [
     Language("typescriptreact", "type script react", ["tsx"]),
     # Language("vba", "vba", ["vba"]),
     Language("vimscript", "vim script", ["vim", "vimrc"]),
+    # These languages doesn't actually have a language mode, but we do have snippets.
+    Language("cpp", "see plus plus", ["cpp", "hpp"]),
+    Language("html", "html", ["html"]),
+    Language("json", "json", ["json"]),
+    Language("shellscript", "shell script", ["sh"]),
+    Language("xml", "xml", ["xml"]),
 ]
 
 # Files without specific extensions but are associated with languages

--- a/core/snippets/snippets/commentLine.snippet
+++ b/core/snippets/snippets/commentLine.snippet
@@ -18,8 +18,3 @@ language: xml | html
 -
 <!-- $0 -->
 ---
-
-language: scm
--
-;; $0
----


### PR DESCRIPTION
#1718 added more snippets. Due to an oversight we are now missing a few language definitions that the snippets are relying on which gives the user errors.
