### PR TITLE
Add csv language definition for snippets

### DIFF
--- a/core/modes/code_languages.py
+++ b/core/modes/code_languages.py
@@ -58,6 +58,7 @@ code_languages = [
     Language("vimscript", "vim script", ["vim", "vimrc"]),
     # These languages doesn't actually have a language mode, but we do have snippets.
     Language("cpp", "see plus plus", ["cpp", "hpp"]),
+    Language("csv", "csv", ["csv"]),
     Language("html", "html", ["html"]),
     Language("json", "json", ["json"]),
     Language("shellscript", "shell script", ["sh"]),


### PR DESCRIPTION
The csv snippet in `commentLine.snippet` results in an unknown language error otherwise.

Related to https://github.com/talonhub/community/pull/1729?