### PR TITLE
Fix regression with `clear all` not working in talon public

### DIFF
--- a/core/edit/edit.py
+++ b/core/edit/edit.py
@@ -91,6 +91,11 @@ class Actions:
         """Delete character to the right"""
         actions.key("delete")
 
+    def delete_all():
+        """Delete all text in the current document"""
+        actions.edit.select_all()
+        actions.edit.delete()
+
     def words_left(n: int):
         """Moves left by n words."""
         for _ in range(n):

--- a/core/edit/edit_command.py
+++ b/core/edit/edit_command.py
@@ -152,7 +152,8 @@ compound_actions = {
     ("delete", "right"): actions.user.delete_right,
     ("delete", "line"): actions.edit.delete_line,
     ("delete", "paragraph"): actions.edit.delete_paragraph,
-    ("delete", "document"): actions.edit.delete_all,
+    # ("delete", "document"): actions.edit.delete_all, # Beta only
+    ("delete", "document"): actions.user.delete_all,
     ("delete", "selection"): actions.edit.delete,
     # Cut to clipboard
     ("cutToClipboard", "line"): actions.user.cut_line,


### PR DESCRIPTION
I have he left the comment indicating that `edit.delete_all` is beta only so we remember to restore it when it lands in public.

