### PR TITLE
Convert some of the snippet parser errors into warnings

### DIFF
--- a/core/snippets/snippets_parser.py
+++ b/core/snippets/snippets_parser.py
@@ -278,7 +278,7 @@ def parse_context_line(
         return
 
     if key in keys:
-        error(file, line, f"Duplicate key '{key}'")
+        warn(file, line, f"Duplicate key '{key}'")
 
     keys.add(key)
 
@@ -297,7 +297,7 @@ def parse_context_line(
             if key.startswith("$"):
                 parse_variable(file, line, get_variable, key, value)
             else:
-                error(file, line, f"Invalid key '{key}'")
+                warn(file, line, f"Unknown key '{key}'")
 
 
 def parse_variable(
@@ -324,7 +324,7 @@ def parse_variable(
         case "wrapperScope":
             get_variable(name).wrapper_scope = value
         case _:
-            error(file, line_numb, f"Invalid variable key '{key}'")
+            warn(file, line_numb, f"Unknown variable key '{key}'")
 
 
 def parse_body(text: str) -> Union[str, None]:
@@ -343,3 +343,7 @@ def parse_vector_value(value: str) -> list[str]:
 
 def error(file: str, line: int, message: str):
     print(f"ERROR | {file}:{line+1} | {message}")
+
+
+def warn(file: str, line: int, message: str):
+    print(f"WARN | {file}:{line+1} | {message}")


### PR DESCRIPTION
Some of the errors from the snippet parser should really be warnings since the snippet still works.