### PR TITLE
Add snippet for Python context manager

### DIFF
--- a/core/snippets/snippets/withStatement.snippet
+++ b/core/snippets/snippets/withStatement.snippet
@@ -1,0 +1,13 @@
+name: withStatement
+phrase: with
+insertionScope: statement
+
+$0.wrapperPhrase: with
+$0.wrapperScope: statement
+---
+
+language: python
+-
+with $1:
+    $0
+---


### PR DESCRIPTION
## Why?
Context managers are fairly frequently used in Python; they're also something of a Python-specfic construct.
For example:
```
with open(filepath) as f:
    file_lines = f.readlines()
```

## What?
Add context manager statement, used with `snip with` and `with wrap`.
`snip context` is a possible alternative name.