### PR TITLE
Make the word wheel optional for stop continuous scrolling commands

### DIFF
--- a/plugin/mouse/continuous_scrolling.talon
+++ b/plugin/mouse/continuous_scrolling.talon
@@ -2,7 +2,7 @@ tag: user.continuous_scrolling
 -
 <number_small>: user.mouse_scroll_set_speed(number_small)
 
-wheel stop: user.mouse_scroll_stop()
-wheel stop here:
+[wheel] stop: user.mouse_scroll_stop()
+[wheel] stop here:
     user.mouse_move_center_active_window()
     user.mouse_scroll_stop()

--- a/plugin/mouse/mouse_scroll.py
+++ b/plugin/mouse/mouse_scroll.py
@@ -77,7 +77,7 @@ def gui_wheel(gui: imgui.GUI):
     gui.text(f"Scroll mode: {continuous_scroll_mode}")
     gui.text(f"say a number between 0 and 99 to set scrolling speed")
     gui.line()
-    if gui.button("Wheel Stop [stop scrolling]"):
+    if gui.button("[Wheel] Stop"):
         actions.user.mouse_scroll_stop()
 
 


### PR DESCRIPTION
Allows stopping continuous scrolling with "stop" and "stop here". 

Something worth discussing: should we indicate the grammar change in the continuous scrolling graphical display and if so how? Should we just replace "wheel stop" in the display with "stop" or should we indicate that the word wheel can optionally be used?