### PR TITLE
Remove /settings from default .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ __pycache__
 *.sw?
 .idea/
 # Locally generated
-/settings
 # we highly recommended against removing the private folder from the gitignore file
 # the directory is used to store sensitive information such as contacts
 /private


### PR DESCRIPTION
We have migrated most of the files that used to be in this directory to be colocated with the .py/.talon implementations of the corresponding features, therefore this is a move to consistency with our policy (in the README) that you should create a fork of community to house your changes and customizations.

Fixes #1732.
