### PR TITLE
Add another match rule to firefox

### DIFF
--- a/apps/firefox/firefox.py
+++ b/apps/firefox/firefox.py
@@ -6,6 +6,7 @@ apps = mod.apps
 apps.firefox = "app.name: Firefox"
 apps.firefox = "app.name: Firefox Developer Edition"
 apps.firefox = "app.name: firefox"
+apps.firefox = "app.name: org.mozilla.firefox"
 apps.firefox = "app.name: Firefox-esr"
 apps.firefox = "app.name: firefox-esr"
 apps.firefox = "app.name: LibreWolf"


### PR DESCRIPTION
On Fedora, I'm unsure why this firefox uses a different app name