### PR TITLE
Fix behavior of unprefixed numbers with mouse grid

### DIFF
--- a/core/numbers/numbers_unprefixed.talon
+++ b/core/numbers/numbers_unprefixed.talon
@@ -1,5 +1,6 @@
 tag: user.unprefixed_numbers
 and not tag: user.continuous_scrolling
+and not tag: user.mouse_grid_showing
 -
 
 <user.number_prose_unprefixed>: "{number_prose_unprefixed}"


### PR DESCRIPTION
Fix so that in mouse grid mode you can say a string of numbers together even with unprefixed numbers active. Without this change, those number keys are sent to the system instead of narrowing the mouse grid.