### PR TITLE
vscode: copy, paste, redo and undo through command palette (2nd attempt)

### DIFF
--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -125,7 +125,9 @@ class EditActions:
 
     def find(text: str = None):
         if text:
-            actions.user.run_rpc_command("editor.actions.findWithArgs", {"searchString": text})
+            actions.user.run_rpc_command(
+                "editor.actions.findWithArgs", {"searchString": text}
+            )
         else:
             actions.user.vscode("actions.find")
 

--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -120,9 +120,6 @@ class EditActions:
     def paste():
         actions.user.vscode("editor.action.clipboardPasteAction")
 
-    def save():
-        actions.user.vscode("workbench.action.files.save")
-
     def find(text: str = None):
         if text:
             actions.user.run_rpc_command(
@@ -143,6 +140,9 @@ class EditActions:
 
     def save_all():
         actions.user.vscode("workbench.action.files.saveAll")
+
+    def save():
+        actions.user.vscode("workbench.action.files.save")
 
     def find_next():
         actions.user.vscode("editor.action.nextMatchFindAction")

--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -105,7 +105,7 @@ class EditActions:
 
     def redo():
         actions.user.vscode("redo")
-    
+
     # talon edit actions
     def indent_more():
         actions.user.vscode("editor.action.indentLines")

--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -106,6 +106,12 @@ class EditActions:
     def redo():
         actions.user.vscode("redo")
 
+    def copy():
+        actions.user.vscode("editor.action.clipboardCopyAction")
+
+    def paste():
+        actions.user.vscode("editor.action.clipboardPasteAction")
+
     # talon edit actions
     def indent_more():
         actions.user.vscode("editor.action.indentLines")

--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -124,10 +124,10 @@ class EditActions:
         actions.user.vscode("workbench.action.files.save")
 
     def find(text: str = None):
-        actions.user.vscode("actions.find")
         if text:
-            actions.sleep("100ms")
-            actions.insert(text)
+            actions.user.run_rpc_command("editor.actions.findWithArgs", {"searchString": text})
+        else:
+            actions.user.vscode("actions.find")
 
 
 @ctx.action_class("edit")

--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -100,6 +100,12 @@ class CodeActions:
 
 @ctx.action_class("edit")
 class EditActions:
+    def undo():
+        actions.user.vscode("undo")
+
+    def redo():
+        actions.user.vscode("redo")
+    
     # talon edit actions
     def indent_more():
         actions.user.vscode("editor.action.indentLines")


### PR DESCRIPTION
Draft PR to implement https://github.com/talonhub/community/pull/1677#issuecomment-2600944142 properly, such that it only applies in the main editor window (or at least, not in modal/system windows).

TODO:

- [x] Figure out how to parse that info from the window title
- [x] Also add find