### PR TITLE
Remove additional \r from default generated CSV files on Windows [1].

### DIFF
--- a/core/user_settings.py
+++ b/core/user_settings.py
@@ -60,7 +60,7 @@ def write_csv_defaults(
     is_spoken_form_first: bool = False,
 ) -> None:
     if not path.is_file() and default is not None:
-        with open(path, "w", encoding="utf-8") as file:
+        with open(path, "w", encoding="utf-8", newline="") as file:
             writer = csv.writer(file)
             writer.writerow(headers)
             for key, value in default.items():


### PR DESCRIPTION
Fixes #1769

[1] https://docs.python.org/3/library/csv.html#id4
