### PR TITLE
Properly support splitting wrapper names with variables

### DIFF
--- a/core/snippets/snippets.py
+++ b/core/snippets/snippets.py
@@ -123,7 +123,7 @@ def get_preferred_snippet(snippets: list[Snippet]) -> Snippet:
 
 def split_wrapper_snippet_name(name: str) -> tuple[str, str]:
     index = name.rindex(".")
-    return name[:index], name[index + 1]
+    return name[:index], name[index + 1 :]
 
 
 def to_wrapper_snippet(snippet: Snippet, variable_name) -> WrapperSnippet:


### PR DESCRIPTION
We only used the first character of the variable name. All of the snippets in community uses a single digit that was fine, but if the user used something like `ifStatement.body` we looked for a variable called `b` instead of `body`.

Fixes #1781
