### PR TITLE
Migrate rust operators

### DIFF
--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -263,7 +263,6 @@ operators = Operators(
     # code_operators_pointer
     POINTER_INDIRECTION="*",
     POINTER_ADDRESS_OF="&",
-    POINTER_STRUCTURE_DEREFERENCE="*",
 )
 
 

--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -2,6 +2,8 @@ from typing import Any, Callable, TypeVar
 
 from talon import Context, Module, actions, settings
 
+from ..tags.operators import Operators
+
 mod = Module()
 # rust specific grammar
 mod.list("code_type_modifier", desc="List of type modifiers for active language")
@@ -221,9 +223,50 @@ ctx.lists["user.code_macros"] = all_macros
 
 ctx.lists["user.code_trait"] = all_traits
 
+operators = Operators(
+    # code_operators_array
+    SUBSCRIPT=lambda: actions.user.insert_between("[", "]"),
+    # code_operators_assignment
+    ASSIGNMENT=" = ",
+    ASSIGNMENT_ADDITION=" += ",
+    ASSIGNMENT_SUBTRACTION=" -= ",
+    ASSIGNMENT_MULTIPLICATION=" *= ",
+    ASSIGNMENT_DIVISION=" /= ",
+    ASSIGNMENT_MODULO=" %= ",
+    ASSIGNMENT_BITWISE_AND=" &= ",
+    ASSIGNMENT_BITWISE_OR=" |= ",
+    ASSIGNMENT_BITWISE_EXCLUSIVE_OR=" ^= ",
+    ASSIGNMENT_BITWISE_LEFT_SHIFT=" <<= ",
+    ASSIGNMENT_BITWISE_RIGHT_SHIFT=" >>= ",
+    # code_operators_bitwise
+    BITWISE_AND=" & ",
+    BITWISE_OR=" | ",
+    BITWISE_EXCLUSIVE_OR=" ^ ",
+    BITWISE_LEFT_SHIFT=" << ",
+    BITWISE_RIGHT_SHIFT=" >> ",
+    # code_operators_math
+    MATH_ADD=" + ",
+    MATH_SUBTRACT=" - ",
+    MATH_MULTIPLY=" * ",
+    MATH_DIVIDE=" / ",
+    MATH_MODULO=" % ",
+    MATH_EXPONENT=lambda: actions.user.insert_between(".pow(", ")"),
+    MATH_EQUAL=" == ",
+    MATH_NOT_EQUAL=" != ",
+    MATH_GREATER_THAN=" > ",
+    MATH_GREATER_THAN_OR_EQUAL=" >= ",
+    MATH_LESS_THAN=" < ",
+    MATH_LESS_THAN_OR_EQUAL=" <= ",
+    MATH_AND=" && ",
+    MATH_OR=" || ",
+    ASSIGNMENT_INCREMENT=" += 1",
+)
 
 @ctx.action_class("user")
 class UserActions:
+    def code_get_operators() -> Operators:
+        return operators
+
     # tag: comment_line
 
     def code_comment_line_prefix():
@@ -348,112 +391,6 @@ class UserActions:
 
     def code_insert_library(text: str, selection: str):
         actions.user.paste(f"use {text}")
-
-    # tag: operators_array
-
-    def code_operator_subscript():
-        actions.auto_insert("[]")
-        actions.edit.left()
-
-    # tag: code_operators_assignment
-
-    def code_operator_assignment():
-        actions.auto_insert(" = ")
-
-    def code_operator_subtraction_assignment():
-        actions.auto_insert(" -= ")
-
-    def code_operator_addition_assignment():
-        actions.auto_insert(" += ")
-
-    def code_operator_multiplication_assignment():
-        actions.auto_insert(" *= ")
-
-    def code_operator_division_assignment():
-        actions.auto_insert(" /= ")
-
-    def code_operator_modulo_assignment():
-        actions.auto_insert(" %= ")
-
-    def code_operator_bitwise_and_assignment():
-        actions.auto_insert(" &= ")
-
-    def code_operator_bitwise_or_assignment():
-        actions.auto_insert(" |= ")
-
-    def code_operator_bitwise_exclusive_or_assignment():
-        actions.auto_insert(" ^= ")
-
-    def code_operator_bitwise_left_shift_assignment():
-        actions.auto_insert(" <<= ")
-
-    def code_operator_bitwise_right_shift_assignment():
-        actions.auto_insert(" >>= ")
-
-    # tag: operators_bitwise
-
-    def code_operator_bitwise_and():
-        actions.auto_insert(" & ")
-
-    def code_operator_bitwise_or():
-        actions.auto_insert(" | ")
-
-    def code_operator_bitwise_exclusive_or():
-        actions.auto_insert(" ^ ")
-
-    def code_operator_bitwise_left_shift():
-        actions.auto_insert(" << ")
-
-    def code_operator_bitwise_right_shift():
-        actions.auto_insert(" >> ")
-
-    # tag: operators_math
-
-    def code_operator_subtraction():
-        actions.auto_insert(" - ")
-
-    def code_operator_addition():
-        actions.auto_insert(" + ")
-
-    def code_operator_multiplication():
-        actions.auto_insert(" * ")
-
-    def code_operator_exponent():
-        actions.auto_insert(".pow()")
-        actions.edit.left()
-
-    def code_operator_division():
-        actions.auto_insert(" / ")
-
-    def code_operator_modulo():
-        actions.auto_insert(" % ")
-
-    def code_operator_equal():
-        actions.auto_insert(" == ")
-
-    def code_operator_not_equal():
-        actions.auto_insert(" != ")
-
-    def code_operator_greater_than():
-        actions.auto_insert(" > ")
-
-    def code_operator_greater_than_or_equal_to():
-        actions.auto_insert(" >= ")
-
-    def code_operator_less_than():
-        actions.auto_insert(" < ")
-
-    def code_operator_less_than_or_equal_to():
-        actions.auto_insert(" <= ")
-
-    def code_operator_and():
-        actions.auto_insert(" && ")
-
-    def code_operator_or():
-        actions.auto_insert(" || ")
-
-    def code_operator_increment():
-        actions.auto_insert(" += 1")
 
     # rust specific grammar
 

--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -261,7 +261,9 @@ operators = Operators(
     MATH_OR=" || ",
     ASSIGNMENT_INCREMENT=" += 1",
     # code_operators_pointer
-    POINTER_STRUCTURE_DEREFERENCE=actions.auto_insert("*")
+    POINTER_INDIRECTION="*",
+    POINTER_ADDRESS_OF="&",
+    POINTER_STRUCTURE_DEREFERENCE="*",
 )
 
 @ctx.action_class("user")

--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -266,6 +266,7 @@ operators = Operators(
     POINTER_STRUCTURE_DEREFERENCE="*",
 )
 
+
 @ctx.action_class("user")
 class UserActions:
     def code_get_operators() -> Operators:

--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -260,6 +260,8 @@ operators = Operators(
     MATH_AND=" && ",
     MATH_OR=" || ",
     ASSIGNMENT_INCREMENT=" += 1",
+    # code_operators_pointer
+    POINTER_STRUCTURE_DEREFERENCE=actions.auto_insert("*")
 )
 
 @ctx.action_class("user")
@@ -393,9 +395,6 @@ class UserActions:
         actions.user.paste(f"use {text}")
 
     # rust specific grammar
-
-    def code_operator_structure_dereference():
-        actions.auto_insert("*")
 
     def code_state_implements():
         actions.auto_insert("impl  {}")

--- a/lang/rust/rust.talon
+++ b/lang/rust/rust.talon
@@ -19,6 +19,7 @@ tag(): user.code_operators_array
 tag(): user.code_operators_assignment
 tag(): user.code_operators_bitwise
 tag(): user.code_operators_math
+tag(): user.code_operators_pointer
 
 settings():
     user.code_private_function_formatter = "SNAKE_CASE"


### PR DESCRIPTION
Migrate the existing rust operators and add pointer operators. 

I think that the original
```python
def code_operator_structure_dereference():
        actions.auto_insert("*")
```
may be mistaken. I migrated that operator as is because I do not know much about rust. 