### PR TITLE
Migrate php operators

### DIFF
--- a/BREAKING_CHANGES.txt
+++ b/BREAKING_CHANGES.txt
@@ -7,6 +7,7 @@ and when the change was applied given the delay between changes being
 submitted and the time they were reviewed and merged.
 
 ---
+* 2025-20-04 Deprecated php commands `(op | is) loosely equal` and `(op | is) loosely not equal` in favor of `is weak equal` and `is weak not equal`. The names of the comparison operators can be updated in lang/tags/operators_math_comparison.talon-list if desired.
 * 2025-03-04 Deprecated javascript commands `(op | is) strict equal` and `(op | is) strict not equal` in favor of `is equal` and `is not equal`. Weak comparison can be done with `is weak equal` and `is weak not equal`.
 * 2025-02-01 Removed snippet language inheritance. From now on typescript will not automatically use javascript snippets. Each snippet need to define every language it should be active in.
 * 2025-01-19 Deprecated a bunch of programming language operator commands in favor of using Talon lists

--- a/lang/php/php.py
+++ b/lang/php/php.py
@@ -26,6 +26,18 @@ operators = Operators(
     ASSIGNMENT_DIVISION=" /= ",
     ASSIGNMENT_MODULO=" %= ",
     ASSIGNMENT_INCREMENT="++",
+    ASSIGNMENT_BITWISE_AND=" &= ",
+    ASSIGNMENT_BITWISE_OR=" |= ",
+    ASSIGNMENT_BITWISE_EXCLUSIVE_OR=" ^= ",
+    ASSIGNMENT_BITWISE_LEFT_SHIFT=" <<= ",
+    ASSIGNMENT_BITWISE_RIGHT_SHIFT=" >>= ",
+    # code_operators_bitwise
+    BITWISE_AND=" & ",
+    BITWISE_OR=" | ",
+    BITWISE_EXCLUSIVE_OR=" ^ ",
+    BITWISE_LEFT_SHIFT=" << ",
+    BITWISE_RIGHT_SHIFT=" >> ",
+    BITWISE_NOT="~",
     # code_operators_math
     MATH_ADD=" + ",
     MATH_SUBTRACT=" - ",

--- a/lang/php/php.py
+++ b/lang/php/php.py
@@ -58,6 +58,7 @@ operators = Operators(
     MATH_OR=" || ",
 )
 
+
 @ctx.action_class("user")
 class UserActions:
     def code_get_operators() -> Operators:

--- a/lang/php/php.py
+++ b/lang/php/php.py
@@ -1,5 +1,7 @@
 from talon import Context, actions, settings
 
+from ..tags.operators import Operators
+
 ctx = Context()
 ctx.matches = r"""
 code.language: php
@@ -15,9 +17,40 @@ ctx.lists["user.code_type"] = {
     "void": "void",
 }
 
+operators = Operators(
+    # code_operators_assignment
+    ASSIGNMENT=" = ",
+    ASSIGNMENT_ADDITION=" += ",
+    ASSIGNMENT_SUBTRACTION=" -= ",
+    ASSIGNMENT_MULTIPLICATION=" *= ",
+    ASSIGNMENT_DIVISION=" /= ",
+    ASSIGNMENT_MODULO=" %= ",
+    ASSIGNMENT_INCREMENT="++",
+    # code_operators_math
+    MATH_ADD=" + ",
+    MATH_SUBTRACT=" - ",
+    MATH_MULTIPLY=" * ",
+    MATH_DIVIDE=" / ",
+    MATH_MODULO=" % ",
+    MATH_EXPONENT=" ** ",
+    MATH_EQUAL=" === ",
+    MATH_NOT_EQUAL=" !== ",
+    MATH_WEAK_EQUAL=" == ",
+    MATH_WEAK_NOT_EQUAL=" != ",
+    MATH_GREATER_THAN=" > ",
+    MATH_GREATER_THAN_OR_EQUAL=" >= ",
+    MATH_LESS_THAN=" < ",
+    MATH_LESS_THAN_OR_EQUAL=" <= ",
+    MATH_NOT="!",
+    MATH_AND=" && ",
+    MATH_OR=" || ",
+)
 
 @ctx.action_class("user")
 class UserActions:
+    def code_get_operators() -> Operators:
+        return operators
+
     def code_self():
         actions.auto_insert("$this")
 
@@ -66,66 +99,6 @@ class UserActions:
     def code_insert_is_not_null():
         actions.auto_insert("isset()")
         actions.edit.left()
-
-    def code_operator_assignment():
-        actions.auto_insert(" = ")
-
-    def code_operator_subtraction():
-        actions.auto_insert(" - ")
-
-    def code_operator_subtraction_assignment():
-        actions.auto_insert(" -= ")
-
-    def code_operator_addition():
-        actions.auto_insert(" + ")
-
-    def code_operator_addition_assignment():
-        actions.auto_insert(" += ")
-
-    def code_operator_multiplication():
-        actions.auto_insert(" * ")
-
-    def code_operator_multiplication_assignment():
-        actions.auto_insert(" *= ")
-
-    def code_operator_exponent():
-        actions.auto_insert(" ** ")
-
-    def code_operator_division():
-        actions.auto_insert(" / ")
-
-    def code_operator_division_assignment():
-        actions.auto_insert(" /= ")
-
-    def code_operator_modulo():
-        actions.auto_insert(" % ")
-
-    def code_operator_modulo_assignment():
-        actions.auto_insert(" %= ")
-
-    def code_operator_equal():
-        actions.auto_insert(" === ")
-
-    def code_operator_not_equal():
-        actions.auto_insert(" !== ")
-
-    def code_operator_greater_than():
-        actions.auto_insert(" > ")
-
-    def code_operator_greater_than_or_equal_to():
-        actions.auto_insert(" >= ")
-
-    def code_operator_less_than():
-        actions.auto_insert(" < ")
-
-    def code_operator_less_than_or_equal_to():
-        actions.auto_insert(" <= ")
-
-    def code_operator_and():
-        actions.auto_insert(" && ")
-
-    def code_operator_or():
-        actions.auto_insert(" || ")
 
     def code_state_if():
         actions.insert("if ()")

--- a/lang/php/php.talon
+++ b/lang/php/php.talon
@@ -22,8 +22,12 @@ settings():
     user.code_protected_variable_formatter = "PRIVATE_CAMEL_CASE"
     user.code_public_variable_formatter = "PRIVATE_CAMEL_CASE"
 
-(op | is) loosely equal: " == "
-(op | is) loosely not equal: " != "
+(op | is) loosely equal: 
+    user.deprecate_command("2025-03-20", "(op | is) loosely equal", "is weak equal")
+    insert(" == ")
+(op | is) loosely not equal: 
+    user.deprecate_command("2025-03-20", "(op | is) loosely not equal", "is weak not equal")
+    insert(" != ")
 
 state try: "try {\n"
 state catch: "catch (\\Throwable $exception) {\n"

--- a/lang/php/php.talon
+++ b/lang/php/php.talon
@@ -22,10 +22,10 @@ settings():
     user.code_protected_variable_formatter = "PRIVATE_CAMEL_CASE"
     user.code_public_variable_formatter = "PRIVATE_CAMEL_CASE"
 
-(op | is) loosely equal: 
+(op | is) loosely equal:
     user.deprecate_command("2025-03-20", "(op | is) loosely equal", "is weak equal")
     insert(" == ")
-(op | is) loosely not equal: 
+(op | is) loosely not equal:
     user.deprecate_command("2025-03-20", "(op | is) loosely not equal", "is weak not equal")
     insert(" != ")
 


### PR DESCRIPTION
Migrate php operators. I believe this is the final operators migration. I added some missing operators. There are some further operators that might be worth adding, but that might be best left to pull requests from people who understand the language. 

I wonder if adding "is loosely equal" and "is loosely not equal" as aliases might be better than deprecation.