### PR TITLE
change "homophones hide"=>"homophones exit"

### DIFF
--- a/core/homophones/homophones.py
+++ b/core/homophones/homophones.py
@@ -162,7 +162,7 @@ def gui(gui: imgui.GUI):
                 actions.user.homophones_hide()
             index = index + 1
 
-        if gui.button("Phones exit"):
+        if gui.button("Phones (hide | exit)"):
             actions.user.homophones_hide()
 
 

--- a/core/homophones/homophones.py
+++ b/core/homophones/homophones.py
@@ -162,7 +162,7 @@ def gui(gui: imgui.GUI):
                 actions.user.homophones_hide()
             index = index + 1
 
-        if gui.button("Phones hide"):
+        if gui.button("Phones exit"):
             actions.user.homophones_hide()
 
 

--- a/core/homophones/homophones.talon
+++ b/core/homophones/homophones.talon
@@ -3,7 +3,7 @@ phones that: user.homophones_show_auto()
 phones force <user.homophones_canonical>:
     user.homophones_force_show(homophones_canonical)
 phones force: user.homophones_force_show_selection()
-phones hide: user.homophones_hide()
+phones exit: user.homophones_hide()
 phones word:
     edit.select_word()
     user.homophones_show_selection()

--- a/core/homophones/homophones.talon
+++ b/core/homophones/homophones.talon
@@ -3,7 +3,7 @@ phones that: user.homophones_show_auto()
 phones force <user.homophones_canonical>:
     user.homophones_force_show(homophones_canonical)
 phones force: user.homophones_force_show_selection()
-phones exit: user.homophones_hide()
+phones [hide | exit]: user.homophones_hide()
 phones word:
     edit.select_word()
     user.homophones_show_selection()

--- a/core/homophones/homophones.talon
+++ b/core/homophones/homophones.talon
@@ -3,7 +3,7 @@ phones that: user.homophones_show_auto()
 phones force <user.homophones_canonical>:
     user.homophones_force_show(homophones_canonical)
 phones force: user.homophones_force_show_selection()
-phones [hide | exit]: user.homophones_hide()
+phones (hide | exit): user.homophones_hide()
 phones word:
     edit.select_word()
     user.homophones_show_selection()


### PR DESCRIPTION
I consistently get misrecognitions when trying to hide the homophones picker menu, since "phones hide" sounds a lot like "phone side", which opens another homophones picker menu.

if other people have this problem too, it might make sense to change the defaults. (and unlike most cases of changing spoken commands, I had to dig a bit to get the gui text to match the .talon file)

I also thought of using "phones close", but that's a homophone too 😆 