### PR TITLE
Add "at symbol" alternative for "at sign".

### DIFF
--- a/core/keys/symbols.py
+++ b/core/keys/symbols.py
@@ -64,7 +64,7 @@ symbols = [
     Symbol("*", ["asterisk"], ["star"]),
     Symbol("#", ["hash sign", "number sign"], ["hash"]),
     Symbol("%", ["percent sign"], ["percent"]),
-    Symbol("@", ["at sign"]),
+    Symbol("@", ["at symbol", "at sign"]),
     Symbol("&", ["ampersand", "and sign"], ["amper"]),
     Symbol("-", ["hyphen"], ["minus", "dash"]),
     Symbol("=", None, ["equals"]),


### PR DESCRIPTION
The latter is not consistently recognized in dictation mode with Conformer D.
