### PR TITLE
Made `file_manager` tag's "folder new" text optional.

### DIFF
--- a/tags/file_manager/file_manager.talon
+++ b/tags/file_manager/file_manager.talon
@@ -29,7 +29,7 @@ manager refresh: user.file_manager_update_lists()
     user.file_manager_open_file(file)
 
 #new folder
-folder new <user.text>: user.file_manager_new_folder(text)
+folder new [<user.text>]: user.file_manager_new_folder(text or "")
 
 #show properties
 properties show: user.file_manager_show_properties()


### PR DESCRIPTION
When used in Windows Explorer, this allows you to think about the name after already having created the folder.