### PR TITLE
Corrected logical flaw in "split..." terminology.

### DIFF
--- a/apps/eclipse/eclipse_win.py
+++ b/apps/eclipse/eclipse_win.py
@@ -95,7 +95,7 @@ class UserActions:
     def split_window_down():
         actions.key("alt-shift-s m")
 
-    def split_window_horizontally():
+    def split_window_horizontal_line():
         actions.key("alt-ctrl-s s")
 
     def split_window_right():
@@ -104,7 +104,7 @@ class UserActions:
     def split_window_up():
         actions.key("alt-shift-s m")
 
-    def split_window_vertically():
+    def split_window_vertical_line():
         actions.key("alt-shift-s s")
 
     def split_window():

--- a/apps/emacs/emacs.py
+++ b/apps/emacs/emacs.py
@@ -109,7 +109,7 @@ class UserActions:
     def split_window():
         actions.user.emacs("split-window-below")
 
-    def split_window_vertically():
+    def split_window_vertical_line():
         actions.user.emacs("split-window-below")
 
     def split_window_up():
@@ -119,7 +119,7 @@ class UserActions:
         actions.user.emacs("split-window-below")
         actions.user.emacs("other-window")
 
-    def split_window_horizontally():
+    def split_window_horizontal_line():
         actions.user.emacs("split-window-right")
 
     def split_window_left():

--- a/apps/jetbrains/jetbrains.py
+++ b/apps/jetbrains/jetbrains.py
@@ -376,10 +376,10 @@ class UserActions:
     # def split_window_left():
     # def split_window_down():
     # def split_window_up():
-    def split_window_vertically():
+    def split_window_vertical_line():
         actions.user.idea("action SplitVertically")
 
-    def split_window_horizontally():
+    def split_window_horizontal_line():
         actions.user.idea("action SplitHorizontally")
 
     def split_flip():

--- a/apps/terminator/terminator_linux.py
+++ b/apps/terminator/terminator_linux.py
@@ -40,10 +40,10 @@ class user_actions:
     def split_window_up():
         actions.key("alt-up")
 
-    def split_window_vertically():
+    def split_window_vertical_line():
         actions.key("shift-ctrl-e")
 
-    def split_window_horizontally():
+    def split_window_horizontal_line():
         actions.key("shift-ctrl-o")
 
     def split_flip():

--- a/apps/tmux/tmux.py
+++ b/apps/tmux/tmux.py
@@ -75,26 +75,26 @@ class UserActions:
         )
 
     def split_window_right():
-        actions.user.split_window_horizontally()
+        actions.user.split_window_horizontal_line()
         actions.user.tmux_execute_command("swap-pane -U -s #P")
 
     def split_window_left():
-        actions.user.split_window_horizontally()
+        actions.user.split_window_horizontal_line()
 
     def split_window_down():
-        actions.user.split_window_vertically()
+        actions.user.split_window_vertical_line()
         actions.user.tmux_execute_command("swap-pane -U -s #P")
 
     def split_window_up():
-        actions.user.split_window_vertically()
+        actions.user.split_window_vertical_line()
 
     def split_flip():
         actions.user.tmux_execute_command("next-layout")
 
-    def split_window_vertically():
+    def split_window_vertical_line():
         actions.user.tmux_execute_command("split-pane")
 
-    def split_window_horizontally():
+    def split_window_horizontal_line():
         actions.user.tmux_execute_command("split-pane -h")
 
     def split_maximize():
@@ -105,7 +105,7 @@ class UserActions:
         actions.user.tmux_execute_command("resize-pane -Z")
 
     def split_window():
-        actions.user.split_window_horizontally()
+        actions.user.split_window_horizontal_line()
 
     def split_clear():
         actions.user.tmux_execute_command_with_confirmation(

--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -246,7 +246,7 @@ class UserActions:
     def split_window_down():
         actions.user.vscode("workbench.action.moveEditorToBelowGroup")
 
-    def split_window_horizontally():
+    def split_window_horizontal_line():
         actions.user.vscode("workbench.action.splitEditorOrthogonal")
 
     def split_window_left():
@@ -258,7 +258,7 @@ class UserActions:
     def split_window_up():
         actions.user.vscode("workbench.action.moveEditorToAboveGroup")
 
-    def split_window_vertically():
+    def split_window_vertical_line():
         actions.user.vscode("workbench.action.splitEditor")
 
     def split_window():
@@ -342,7 +342,7 @@ class UserActions:
     def tab_duplicate():
         # Duplicates the current tab into a new tab group
         # vscode does not allow duplicate tabs in the same tab group, and so is implemented through splits
-        actions.user.split_window_vertically()
+        actions.user.split_window_vertical_line()
 
     # tabs.py support end
 

--- a/apps/windows_terminal/windows_terminal.py
+++ b/apps/windows_terminal/windows_terminal.py
@@ -123,12 +123,12 @@ class UserActions:
             '"Split up" is not possible in windows terminal without special configuration. Use "split horizontally" instead.'
         )
 
-    def split_window_vertically():
-        """Splits window vertically"""
+    def split_window_vertical_line():
+        """Splits the window using a vertical split line"""
         actions.key("shift-alt-plus")
 
-    def split_window_horizontally():
-        """Splits window horizontally"""
+    def split_window_horizontal_line():
+        """Splits the window using a horizontal split line"""
         actions.key("shift-alt-minus")
 
     def split_flip():

--- a/tags/splits/splits.py
+++ b/tags/splits/splits.py
@@ -18,11 +18,11 @@ class Actions:
     def split_window_up():
         """Move active tab to upper split"""
 
-    def split_window_vertically():
-        """Splits window vertically"""
+    def split_window_vertical_line():
+        """Splits the window using a vertical split line"""
 
-    def split_window_horizontally():
-        """Splits window horizontally"""
+    def split_window_horizontal_line():
+        """Splits the window using a horizontal split line"""
 
     def split_flip():
         """Flips the orietation of the active split"""

--- a/tags/splits/splits.talon
+++ b/tags/splits/splits.talon
@@ -1,11 +1,36 @@
 tag: user.splits
 -
+
+# Note: The verb "to split" (the process) and the noun "the split" (the result)
+# logically refer to different axes:
+#
+#                     |
+#                     |
+#                     |
+# --------------------+--------------------
+#      Splitting along|the hor. axis...
+#                     |
+#                     | ...creates
+#                     | a split along
+#                     | the vert. axis.
+#
+# This is why the phrase "split vertically" to create a vertical split would be
+# incorrect, because it implies that "split" is a verb. With "split vertical" - when
+# accepting the different word order as is customary in this repository - "split" can be
+# understood as a noun - just like in "split clear" - and is thus correctly referring to
+# the resulting split line. This way, we have accurate phrases that still harmonize with
+# general software conventions.
+#
+# In phrases like "split right" on the other hand, "split" has to be understood as a
+# verb, because, in this case, it means "to the right" (horizontal axis), creating a
+# split line on the other, the vertical axis.
+
 split right: user.split_window_right()
 split left: user.split_window_left()
 split down: user.split_window_down()
 split up: user.split_window_up()
-split (vertically | vertical): user.split_window_vertically()
-split (horizontally | horizontal): user.split_window_horizontally()
+split (vertical | why): user.split_window_vertical_line()
+split (horizontal | ex): user.split_window_horizontal_line()
 split flip: user.split_flip()
 split max: user.split_maximize()
 split reset: user.split_reset()


### PR DESCRIPTION
Also added terse variants to refer to split axes: "split why" for "split vertical", and "split ex" for "split horizontal".

`splits.talon` describes the reasoning behind this. This is similar to stacking layouts from UI frameworks ([React](https://mui.com/material-ui/react-stack/#direction), [Slint](https://docs.slint.dev/latest/docs/slint/guide/language/coding/positioning-and-layouts/#verticallayout-and-horizontallayout)) where the stacking direction is opposite to the direction of the split lines between the cells.