### PR TITLE
Tab handling improvements/extensions

### DIFF
--- a/core/windows_and_tabs/tabs.py
+++ b/core/windows_and_tabs/tabs.py
@@ -12,10 +12,10 @@ class tab_actions:
         actions.app.tab_close()
 
     def tab_duplicate():
-        """Duplicates the current tab."""
+        """Duplicates the current tab"""
 
     def tab_final():
         """Jumps to the final tab"""
 
     def tab_jump(number: int):
-        """Jumps to the specified tab"""
+        """Jumps to a tab by its one-based index"""

--- a/core/windows_and_tabs/tabs.py
+++ b/core/windows_and_tabs/tabs.py
@@ -25,3 +25,12 @@ class tab_actions:
 
     def tab_move_right():
         """Move the current tab one tab to the right"""
+
+    def tab_switcher_focus(text: str):
+        """Focus a tab using tab search"""
+
+    def tab_switcher_focus_last():
+        """Focus last tab"""
+
+    def tab_switcher_menu():
+        """Shows the app's tab switcher"""

--- a/core/windows_and_tabs/tabs.py
+++ b/core/windows_and_tabs/tabs.py
@@ -5,12 +5,6 @@ mod = Module()
 
 @mod.action_class
 class tab_actions:
-    def tab_jump(number: int):
-        """Jumps to the specified tab"""
-
-    def tab_final():
-        """Jumps to the final tab"""
-
     def tab_close_wrapper():
         """Closes the current tab.
         Exists so that apps can implement their own delay before running tab_close() to handle repetitions better.
@@ -19,3 +13,9 @@ class tab_actions:
 
     def tab_duplicate():
         """Duplicates the current tab."""
+
+    def tab_final():
+        """Jumps to the final tab"""
+
+    def tab_jump(number: int):
+        """Jumps to the specified tab"""

--- a/core/windows_and_tabs/tabs.py
+++ b/core/windows_and_tabs/tabs.py
@@ -19,3 +19,9 @@ class tab_actions:
 
     def tab_jump(number: int):
         """Jumps to a tab by its one-based index"""
+
+    def tab_move_left():
+        """Move the current tab one tab to the left"""
+
+    def tab_move_right():
+        """Move the current tab one tab to the right"""

--- a/core/windows_and_tabs/tabs.talon
+++ b/core/windows_and_tabs/tabs.talon
@@ -1,10 +1,11 @@
 tag: user.tabs
 -
 tab (open | new): app.tab_open()
+tab (reopen | restore): app.tab_reopen()
+tab (duplicate | clone): user.tab_duplicate()
+tab close: user.tab_close_wrapper()
+
 tab (last | previous): app.tab_previous()
 tab next: app.tab_next()
-tab close: user.tab_close_wrapper()
-tab (reopen | restore): app.tab_reopen()
 go tab <number>: user.tab_jump(number)
 go tab final: user.tab_final()
-tab (duplicate | clone): user.tab_duplicate()

--- a/core/windows_and_tabs/tabs.talon
+++ b/core/windows_and_tabs/tabs.talon
@@ -5,7 +5,11 @@ tab (reopen | restore): app.tab_reopen()
 tab (duplicate | clone): user.tab_duplicate()
 tab close: user.tab_close_wrapper()
 
-tab (last | previous): app.tab_previous()
-tab next: app.tab_next()
+tab (last | previous | left | up): app.tab_previous()
+tab (next | right | down): app.tab_next()
 go tab <number>: user.tab_jump(number)
 go tab final: user.tab_final()
+
+tab move (left | up): user.tab_move_left()
+tab move (right | down): user.tab_move_right()
+tab detach: app.tab_detach()

--- a/core/windows_and_tabs/tabs.talon
+++ b/core/windows_and_tabs/tabs.talon
@@ -10,6 +10,10 @@ tab (next | right | down): app.tab_next()
 go tab <number>: user.tab_jump(number)
 go tab final: user.tab_final()
 
+tab focus <user.text>: user.tab_switcher_focus(text)
+tab focus$: user.tab_switcher_menu()
+tab focus last: user.tab_switcher_focus_last()
+
 tab move (left | up): user.tab_move_left()
 tab move (right | down): user.tab_move_right()
 tab detach: app.tab_detach()

--- a/core/windows_and_tabs/tabs_win.py
+++ b/core/windows_and_tabs/tabs_win.py
@@ -1,0 +1,15 @@
+from talon import Context, actions
+
+ctx = Context()
+ctx.matches = r"""
+os: windows
+"""
+
+
+@ctx.action_class("user")
+class UserActions:
+    def tab_move_left():
+        actions.key("ctrl-shift-pageup")
+
+    def tab_move_right():
+        actions.key("ctrl-shift-pagedown")


### PR DESCRIPTION
See commits.

If you're asking yourself what apps support a tab switcher that can be sufficiently controlled, Directory Opus does, for which I wrote a voice command set. I know that Firefox also has a tab switcher, but - to my knowledge - doesn't allow control about it like persistently showing it instead of only while holding a modifier key down. But I guess there's a chance that such apps will make persistent tab switcher dialogs available in the future, if their developers learn that it may be useful.

I saw Talon comes with an `app.tab_detach()` function slot, so I also made a phrase for it. It wasn't used before.