### PR TITLE
Equalize `vscode_and_wait()` outlier in `vscode.py`.

### DIFF
--- a/apps/vscode/vscode.py
+++ b/apps/vscode/vscode.py
@@ -241,7 +241,7 @@ class UserActions:
         actions.user.vscode("workbench.action.focusLeftGroup")
 
     def split_next():
-        actions.user.vscode_and_wait("workbench.action.focusRightGroup")
+        actions.user.vscode("workbench.action.focusRightGroup")
 
     def split_window_down():
         actions.user.vscode("workbench.action.moveEditorToBelowGroup")


### PR DESCRIPTION
It just stood out to me that `split_next()` was the only function in this file that calls `vscode_and_wait()`. All other functions, including very similar ones like `split_last()`, call `vscode()`.

If this is in fact correct, just close the PR.