### PR TITLE
Made neglected `app.preferences()` available as phrase.

### DIFF
--- a/apps/opera/opera_win_linux.py
+++ b/apps/opera/opera_win_linux.py
@@ -39,6 +39,9 @@ class UserActions:
 
 @ctx.action_class("app")
 class AppActions:
+    def preferences():
+        actions.key("alt-p")
+
     def tab_next():
         actions.key("ctrl-pagedown")
 

--- a/core/windows_and_tabs/window_management.talon
+++ b/core/windows_and_tabs/window_management.talon
@@ -3,6 +3,7 @@ window next: app.window_next()
 window last: app.window_previous()
 window close: app.window_close()
 window hide: app.window_hide()
+app (preferences | prefs | settings): app.preferences()
 focus <user.running_applications>: user.switcher_focus(running_applications)
 # following only works on windows. Can't figure out how to make it work for mac. No idea what the equivalent for linux would be.
 focus$: user.switcher_menu()

--- a/core/windows_and_tabs/windows_and_tabs_linux.py
+++ b/core/windows_and_tabs/windows_and_tabs_linux.py
@@ -10,8 +10,6 @@ os: linux
 
 @ctx.action_class("app")
 class AppActions:
-    # app.preferences()
-
     def tab_close():
         actions.key("ctrl-w")
 

--- a/core/windows_and_tabs/windows_and_tabs_win.py
+++ b/core/windows_and_tabs/windows_and_tabs_win.py
@@ -10,8 +10,6 @@ os: windows
 
 @ctx.action_class("app")
 class AppActions:
-    # app.preferences()
-
     def tab_close():
         actions.key("ctrl-w")
 


### PR DESCRIPTION
Following <https://github.com/talonhub/community/pull/1841#pullrequestreview-2813260862>.

- Implemented it for Opera. \[Tested it under Windows.\]
- `windows_and_tabs_mac.py` already implements it generically (which is correct for Opera [\[**proof\]**](https://help.opera.com/en/latest/shortcuts/#browserKeys)).