### PR TITLE
Commented out EditActions that don't work with the default iterm2 settings

### DIFF
--- a/apps/iterm/iterm.py
+++ b/apps/iterm/iterm.py
@@ -15,13 +15,13 @@ directories_to_remap = {}
 directories_to_exclude = {}
 
 
-@ctx.action_class("edit")
-class EditActions:
-    def line_start():
-        actions.key("home")
+# @ctx.action_class("edit")
+# class EditActions:
+#     def line_start():
+#         actions.key("home")
 
-    def line_end():
-        actions.key("end")
+#     def line_end():
+#         actions.key("end")
 
 
 @ctx.action_class("user")


### PR DESCRIPTION
Now it defaults to ctrl-a and ctrl-e in readline.py which always works.
