### PR TITLE
Migrate sql to snippets

### DIFF
--- a/core/snippets/snippets/commentLine.snippet
+++ b/core/snippets/snippets/commentLine.snippet
@@ -18,3 +18,8 @@ language: xml | html
 -
 <!-- $0 -->
 ---
+
+language: sql
+-
+-- $0
+---

--- a/core/snippets/snippets/functionCall.snippet
+++ b/core/snippets/snippets/functionCall.snippet
@@ -5,7 +5,7 @@ insertionScope: statement
 $0.wrapperPhrase: call
 ---
 
-language: c | cpp | csharp | python | talon | java | javascript | typescript | javascriptreact | typescriptreact
+language: c | cpp | csharp | python | talon | java | javascript | typescript | javascriptreact | typescriptreact | sql
 -
 $1($0)
 ---

--- a/core/snippets/snippets/sql.snippet
+++ b/core/snippets/snippets/sql.snippet
@@ -1,0 +1,20 @@
+language: sql
+---
+
+name: createTable
+phrase: create table
+insertionScope: statement
+-
+CREATE TABLE $1(
+    $0
+);
+---
+
+name: withStatement
+phrase: with
+insertionScope: statement
+-
+WITH $1 AS (
+        SELECT $0
+)
+---

--- a/lang/sql/sql.py
+++ b/lang/sql/sql.py
@@ -43,7 +43,10 @@ class UserActions:
         actions.auto_insert(" IS NOT NULL")
 
     def code_comment_line_prefix():
-        actions.auto_insert("-- ")
+        actions.user.insert_snippet_by_name("commentLine")
 
     def code_insert_function(text: str, selection: str):
-        actions.user.insert_between(f"{text}({selection or ''}", ")")
+        substitutions = {"1": text}
+        if selection:
+            substitutions["0"] = selection
+        actions.user.insert_snippet_by_name("functionCall", substitutions)

--- a/lang/sql/sql.talon
+++ b/lang/sql/sql.talon
@@ -22,16 +22,7 @@ inner join using: user.insert_between("INNER JOIN ", " USING ")
 left outer join: user.insert_between("LEFT OUTER JOIN ", " ON ")
 right outer join: user.insert_between("RIGHT OUTER JOIN ", " ON ")
 
-with:
-    key(enter up)
-    "WITH  AS ("
-    key(enter tab)
-    "SELECT "
-    key(enter shift-tab)
-    edit.extend_line_end()
-    edit.delete()
-    ") "
-    key(delete up:2 right:3)
+with: user.insert_snippet_by_name("withStatement")
 
 column:
     key(return)


### PR DESCRIPTION
A possible regression is that the space after the close parentheses for the with command is lost when migrated to snippets because a space added to the snippet after the parentheses gets ignored. Based on what I remember about SQL and some quick research, that does not seem consequential, but it may be worth checking with people who use SQL more than I do if this is a regression or not.