### PR TITLE
Use snippet for talon comment action

### DIFF
--- a/lang/talon/talon.py
+++ b/lang/talon/talon.py
@@ -135,7 +135,7 @@ class UserActions:
         return operators
 
     def code_comment_line_prefix():
-        actions.auto_insert("#")
+        actions.user.insert_snippet_by_name("commentLine")
 
     def code_insert_function(text: str, selection: str):
         text += f"({selection or ''})"


### PR DESCRIPTION
This migrates the talon programming code to use the snippet system given that the comment action was the only thing that seemed to need migration.