### PR TITLE
Migrate markdown link command to use snippet

### DIFF
--- a/lang/markdown/markdown.talon
+++ b/lang/markdown/markdown.talon
@@ -42,5 +42,4 @@ list six:
     user.insert_snippet("```{markdown_code_block_language}\n$0\n```")
 
 link:
-    "[]()"
-    key(left:3)
+    user.insert_snippet_by_name("link")


### PR DESCRIPTION
Nothing else seemed to me to require migration for markdown.