### PR TITLE
Start migrating elixir to snippets

### DIFF
--- a/core/snippets/snippets/caseStatement.snippet
+++ b/core/snippets/snippets/caseStatement.snippet
@@ -15,3 +15,9 @@ insertionScope: branch
 case $1:
     $0
 ---
+
+language: elixir
+-
+$1 ->
+    $0
+---

--- a/core/snippets/snippets/commentLine.snippet
+++ b/core/snippets/snippets/commentLine.snippet
@@ -9,7 +9,7 @@ language: c | cpp | csharp | json | java | javascript | typescript | javascriptr
 // $0
 ---
 
-language: python | talon | csv
+language: python | talon | csv | elixir
 -
 # $0
 ---

--- a/core/snippets/snippets/defaultStatement.snippet
+++ b/core/snippets/snippets/defaultStatement.snippet
@@ -13,3 +13,9 @@ language: python
 case _:
     $0
 ---
+
+language: elixir
+-
+_ ->
+    $0
+---

--- a/core/snippets/snippets/elixir.snippet
+++ b/core/snippets/snippets/elixir.snippet
@@ -1,0 +1,12 @@
+language: elixir
+---
+
+name: conditionStatement
+phrase: cond
+insertionScope: statement
+-
+cond do
+    $1 ->
+        $0
+end
+---

--- a/core/snippets/snippets/elseStatement.snippet
+++ b/core/snippets/snippets/elseStatement.snippet
@@ -19,7 +19,7 @@ else:
     $0
 ---
 
-language: lua
+language: lua | elixir
 -
 else
     $0

--- a/core/snippets/snippets/genericForLoopStatement.snippet
+++ b/core/snippets/snippets/genericForLoopStatement.snippet
@@ -1,0 +1,11 @@
+name: genericForLoopStatement
+phrase: for
+insertionScope: statement
+---
+
+language: elixir
+-
+for $1 do
+	$0
+end
+---

--- a/core/snippets/snippets/ifStatement.snippet
+++ b/core/snippets/snippets/ifStatement.snippet
@@ -27,3 +27,10 @@ if $1 then
     $0
 end
 ---
+
+language: elixir
+-
+if $1 do
+    $0
+end
+---

--- a/core/snippets/snippets/switchStatement.snippet
+++ b/core/snippets/snippets/switchStatement.snippet
@@ -15,3 +15,10 @@ language: python
 match $1:
     $0
 ---
+
+language: elixir
+-
+case $1 do
+    $0
+end
+---

--- a/core/snippets/snippets/tryStatement.snippet
+++ b/core/snippets/snippets/tryStatement.snippet
@@ -15,3 +15,10 @@ language: python
 try:
     $0
 ---
+
+language: elixir
+-
+try do
+    $0
+end
+---

--- a/core/snippets/snippets/whileLoopStatement.snippet
+++ b/core/snippets/snippets/whileLoopStatement.snippet
@@ -15,3 +15,10 @@ language: python
 while $1:
     $0
 ---
+
+language: elixir
+-
+while $1 do
+    $0
+end
+---

--- a/lang/elixir/elixir.py
+++ b/lang/elixir/elixir.py
@@ -67,7 +67,7 @@ class UserActions:
         return operators
 
     def code_comment_line_prefix():
-        actions.insert("# ")
+        actions.user.insert_snippet_by_name("commentLine")
 
     def code_self():
         actions.auto_insert("self")
@@ -88,23 +88,22 @@ class UserActions:
         actions.insert(" != nil")
 
     def code_state_if():
-        actions.user.insert_between("if ", " do\nend")
+        actions.user.insert_snippet_by_name("ifStatement")
 
     def code_state_else_if():
         actions.user.insert_between("else if ", " do\nend")
 
     def code_state_else():
-        actions.insert("else\nend")
-        actions.key("enter")
+        actions.user.insert_snippet_by_name("elseStatement")
 
     def code_state_case():
         actions.user.insert_between("case ", " do\nend")
 
     def code_state_for():
-        actions.user.insert_between("for ", " do\nend")
+        actions.user.insert_snippet_by_name("genericForLoopStatement")
 
     def code_state_while():
-        actions.user.insert_between("while ", " do\nend")
+        actions.user.insert_snippet_by_name("whileLoopStatement")
 
     def code_define_class():
         # Elixir doesn't have classes, so this is not applicable

--- a/lang/elixir/elixir.talon
+++ b/lang/elixir/elixir.talon
@@ -31,8 +31,6 @@ state try: "try do"
 state rescue: "rescue"
 state after: "after"
 state end: "end"
-state while: user.insert_snippet_by_name("whileLoopStatement")
-state for: user.insert_snippet_by_name("genericForLoopStatement")
 
 op pipe: " |> "
 

--- a/lang/elixir/elixir.talon
+++ b/lang/elixir/elixir.talon
@@ -31,6 +31,8 @@ state try: "try do"
 state rescue: "rescue"
 state after: "after"
 state end: "end"
+state while: user.insert_snippet_by_name("whileLoopStatement")
+state for: user.insert_snippet_by_name("genericForLoopStatement")
 
 op pipe: " |> "
 


### PR DESCRIPTION
There does not seem to be an else if statement in the language, so I did not try to migrate that action. 
I was not sure what to do about the fact that a switch statement is called a case statement in the language, so changing the code state case action to do what that action usually does would not reflect what things are named in this language. 
There is an issue with actions conflicting with commands with the elixir setup, so I migrated the actions but left the commands alone. 
I followed the structure in the existing talon file of explicitly defining state commands. 
I am not familiar enough with the language to know how to properly handle the import actions, which are currently unusable anyways because they do not correspond to action definitions.