### PR TITLE
Accept string as edit command arguments

### DIFF
--- a/core/edit/edit.talon
+++ b/core/edit/edit.talon
@@ -1,5 +1,10 @@
-# Compound of action(select, clear, copy, cut, paste, etc.) and modifier(word, line, etc.) commands for editing text.
+# Compound of action(select, clear, copy, cut, paste, etc.) and modifier(word,
+# line, etc.) commands for editing text.
 # eg: "select line", "clear all"
+# For overriding or creating aliases for specific actions, this function will
+# also accept strings, e.g. `user.edit_command("delete", "wordLeft")`.
+# See edit_command_modifiers.py to discover the correct string for the modify argument,
+# and `edit_command_actions.py` `simple_action_callbacks` to find strings for the action argument.
 <user.edit_action> <user.edit_modifier>: user.edit_command(edit_action, edit_modifier)
 
 # Zoom

--- a/core/edit/edit_command.py
+++ b/core/edit/edit_command.py
@@ -165,8 +165,16 @@ compound_actions = {
 
 @mod.action_class
 class Actions:
-    def edit_command(action: EditAction, modifier: EditModifier):
-        """Perform edit command"""
+    def edit_command(action: EditAction | str, modifier: EditModifier | str):
+        """Perform edit command with associated modifier.
+        Action and modifier can be dataclasses (formed from utterances via
+        capture) or str, for use in scripts. Strings should match the action or
+        modifier types declared here or in edit_command_modifiers.py or
+        edit_command_actions.py"""
+        if isinstance(modifier, str):
+            modifier = EditModifier(modifier)
+        if isinstance(action, str):
+            action = EditSimpleAction(action)
         key = (action.type, modifier.type)
         count = modifier.count
 


### PR DESCRIPTION
Fixes #1809 

Permits mapping actions like `bonk: user.edit_command("delete", "wordLeft")`

For now the discoverability of the commands is low, so at some point I will also open a pr to include a doc page on customizing edit actions