### PR TITLE
Refactor edit commands and create readline for vi mode

### DIFF
--- a/core/edit/edit.talon
+++ b/core/edit/edit.talon
@@ -1,5 +1,10 @@
-# Compound of action(select, clear, copy, cut, paste, etc.) and modifier(word, line, etc.) commands for editing text.
+# Compound of action(select, clear, copy, cut, paste, etc.) and modifier(word,
+# line, etc.) commands for editing text.
 # eg: "select line", "clear all"
+# For overriding or creating aliases for specific actions, this function will
+# also accept strings, e.g. `user.edit_command("delete", "wordLeft")`.
+# See edit_command_modifiers.py to discover the correct string for the modify argument,
+# and `edit_command_actions.py` `simple_action_callbacks` to find strings for the action argument.
 <user.edit_action> <user.edit_modifier>: user.edit_command(edit_action, edit_modifier)
 
 # Zoom

--- a/core/edit/edit_command.py
+++ b/core/edit/edit_command.py
@@ -165,8 +165,16 @@ compound_actions = {
 
 @mod.action_class
 class Actions:
-    def edit_command(action: EditAction, modifier: EditModifier):
-        """Perform edit command"""
+    def edit_command(action: EditAction | str, modifier: EditModifier | str):
+        """Perform edit command with associated modifier.
+        Action and modifier can be dataclasses (formed from utterances via
+        capture) or str, for use in scripts. Strings should match the action or
+        modifier types declared here or in edit_command_modifiers.py or
+        edit_command_actions.py"""
+        if isinstance(modifier, str):
+            modifier = EditModifier(modifier)
+        if isinstance(action, str):
+            action = EditSimpleAction(action)
         key = (action.type, modifier.type)
         count = modifier.count
 

--- a/core/edit/edit_command.py
+++ b/core/edit/edit_command.py
@@ -1,7 +1,7 @@
 from talon import Module, actions, settings
 
-from .edit_command_actions import EditAction, run_action_callback
-from .edit_command_modifiers import EditModifier, run_modifier_callback
+from .edit_command_actions import EditAction, EditSimpleAction
+from .edit_command_modifiers import EditModifier
 
 mod = Module()
 
@@ -60,7 +60,7 @@ def select_lines(action, direction, count):
     # ensure we take the start/end of the line too!
     extend_line_callback()
     actions.sleep(selection_delay)
-    run_action_callback(action)
+    actions.user.run_action_callback(action)
 
 
 def select_words(action, direction, count):
@@ -74,7 +74,7 @@ def select_words(action, direction, count):
         selection_callback()
         actions.sleep(selection_delay)
 
-    run_action_callback(action)
+    actions.user.run_action_callback(action)
 
 
 def word_movement_handler(action, direction, count):
@@ -187,5 +187,5 @@ class Actions:
                 compound_actions[key]()
             return
 
-        run_modifier_callback(modifier)
-        run_action_callback(action)
+        actions.user.run_modifier_callback(modifier)
+        actions.user.run_action_callback(action)

--- a/core/edit/edit_command_actions.py
+++ b/core/edit/edit_command_actions.py
@@ -98,7 +98,7 @@ class Actions:
         action_type = action.type
 
         if action_type in simple_action_callbacks:
-            callback = simple_action_callbacks[action_type]
+            callback = actions.user.get_simple_action_callback(action_type)
             callback()
             return
 
@@ -117,3 +117,8 @@ class Actions:
 
             case _:
                 raise ValueError(f"Unknown edit action: {action_type}")
+
+    def get_simple_action_callback(action_type: str):
+        """Convert a edit action type created from a string into its associated Callback"""
+        assert action_type in simple_action_callbacks
+        return simple_action_callbacks[action_type]

--- a/core/edit/edit_command_actions.py
+++ b/core/edit/edit_command_actions.py
@@ -88,26 +88,32 @@ simple_action_callbacks: dict[str, Callable] = {
 }
 
 
-def run_action_callback(action: EditAction):
-    action_type = action.type
+@mod.action_class
+class Actions:
+    def run_action_callback(action: EditAction):
+        """
+        Run a callback that applies an edit action to the selected
+        Intended for internal use and overwriting
+        """
+        action_type = action.type
 
-    if action_type in simple_action_callbacks:
-        callback = simple_action_callbacks[action_type]
-        callback()
-        return
+        if action_type in simple_action_callbacks:
+            callback = simple_action_callbacks[action_type]
+            callback()
+            return
 
-    match action_type:
-        case "insert":
-            assert isinstance(action, EditInsertAction)
-            actions.insert(action.text)
+        match action_type:
+            case "insert":
+                assert isinstance(action, EditInsertAction)
+                actions.insert(action.text)
 
-        case "wrapWithDelimiterPair":
-            assert isinstance(action, EditWrapAction)
-            return lambda: actions.user.delimiter_pair_wrap_selection(action.pair)
+            case "wrapWithDelimiterPair":
+                assert isinstance(action, EditWrapAction)
+                return lambda: actions.user.delimiter_pair_wrap_selection(action.pair)
 
-        case "applyFormatter":
-            assert isinstance(action, EditFormatAction)
-            actions.user.formatters_reformat_selection(action.formatters)
+            case "applyFormatter":
+                assert isinstance(action, EditFormatAction)
+                actions.user.formatters_reformat_selection(action.formatters)
 
-        case _:
-            raise ValueError(f"Unknown edit action: {action_type}")
+            case _:
+                raise ValueError(f"Unknown edit action: {action_type}")

--- a/core/edit/edit_command_modifiers.py
+++ b/core/edit/edit_command_modifiers.py
@@ -71,11 +71,14 @@ class Actions:
         Run a callback that selects or prepares text ready to apply and edit action.
         Intended for internal use and overwriting
         """
+        count = modifier.count
+        modifier = actions.user.get_modifier_callback(EditModifier)
+        for i in range(1, count + 1):
+            modifier.callback()
+
+    def get_modifier_callback(modifier: EditModifier):
+        """Convert an edit modifier created from a string into its associated EditModifierCallback"""
         modifier_type = modifier.type
         if modifier_type not in modifier_dictionary:
             raise ValueError(f"Unknown edit modifier: {modifier_type}")
-
-        count = modifier.count
-        modifier = modifier_dictionary[modifier_type]
-        for i in range(1, count + 1):
-            modifier.callback()
+        return modifier_dictionary[modifier_type]

--- a/core/edit/edit_command_modifiers.py
+++ b/core/edit/edit_command_modifiers.py
@@ -64,12 +64,18 @@ modifier_dictionary: dict[str, EditModifierCallback] = {
 }
 
 
-def run_modifier_callback(modifier: EditModifier):
-    modifier_type = modifier.type
-    if modifier_type not in modifier_dictionary:
-        raise ValueError(f"Unknown edit modifier: {modifier_type}")
+@mod.action_class
+class Actions:
+    def run_modifier_callback(modifier: EditModifier):
+        """
+        Run a callback that selects or prepares text ready to apply and edit action.
+        Intended for internal use and overwriting
+        """
+        modifier_type = modifier.type
+        if modifier_type not in modifier_dictionary:
+            raise ValueError(f"Unknown edit modifier: {modifier_type}")
 
-    count = modifier.count
-    modifier = modifier_dictionary[modifier_type]
-    for i in range(1, count + 1):
-        modifier.callback()
+        count = modifier.count
+        modifier = modifier_dictionary[modifier_type]
+        for i in range(1, count + 1):
+            modifier.callback()

--- a/core/edit/edit_command_modifiers.py
+++ b/core/edit/edit_command_modifiers.py
@@ -72,7 +72,7 @@ class Actions:
         Intended for internal use and overwriting
         """
         count = modifier.count
-        modifier = actions.user.get_modifier_callback(EditModifier)
+        modifier = actions.user.get_modifier_callback(modifier)
         for i in range(1, count + 1):
             modifier.callback()
 

--- a/core/tags.py
+++ b/core/tags.py
@@ -10,6 +10,7 @@ tagList = [
     "generic_windows_shell",
     "generic_unix_shell",
     "readline",
+    "readline_vi",
     "taskwarrior",  # commandline tag for taskwarrior commands
     "tmux",
 ]

--- a/tags/terminal/readline_vi.py
+++ b/tags/terminal/readline_vi.py
@@ -9,8 +9,9 @@ ctx.matches = """
 tag: user.readline_vi
 """
 
+
 @dataclass
-class PendingSelection():
+class PendingSelection:
     motion: str
     endAction: str
     count: int = 1
@@ -20,15 +21,16 @@ pendingSelection: PendingSelection | None = None
 
 
 edit_action_vi_keys: dict[str, str] = {
-        "cut": "c",
-        "delete": "c",
-        "goBefore": "",
-        "goAfter": "",
-        # We can't actually use the clipboard for these operations
-        "copyToClipboard": "y",
-        "cutToClipboard": "c",
-        "pasteFromClipboard": "y",
+    "cut": "c",
+    "delete": "c",
+    "goBefore": "",
+    "goAfter": "",
+    # We can't actually use the clipboard for these operations
+    "copyToClipboard": "y",
+    "cutToClipboard": "c",
+    "pasteFromClipboard": "y",
 }
+
 
 def normal_cmd(keys):
     actions.key("escape")
@@ -87,10 +89,8 @@ class EditActions:
         pendingSelection = PendingSelection("w", "i")
 
 
-
 @ctx.action_class("user")
 class Actions:
-
     def run_action_callback(action):
         """
         Run a callback that applies an edit action to the selected

--- a/tags/terminal/readline_vi.py
+++ b/tags/terminal/readline_vi.py
@@ -1,0 +1,214 @@
+from talon import Context, actions
+from typing import Callable
+from dataclasses import dataclass
+
+
+ctx = Context()
+ctx.matches = """
+tag: user.readline_vi
+"""
+
+@dataclass
+class PendingSelection():
+    motion: str
+    endAction: str
+    count: int = 1
+
+
+# @dataclass
+# class EditModifier:
+#     type: str
+#     count: int = 1
+
+@dataclass
+class EditModifierCallback:
+    modifier: str
+    callback: str
+
+
+pendingSelection: PendingSelection = None
+
+
+modifiers: dict[str, EditModifierCallback] = {
+    item.modifier: item for item in
+    [
+        EditModifierCallback("word", "iwi"),
+        EditModifierCallback("wordLeft", "bi"),
+        EditModifierCallback("wordRight", "wa"),
+        EditModifierCallback("line", "_i"),
+        EditModifierCallback("lineEnd", "$a"),
+        EditModifierCallback("lineStart", "0i"),
+    ]
+}
+
+edit_action_vi_keys: dict[str, str] = {
+        "cut": "c",
+        "delete": "c",
+        "goBefore": "",
+        "goAfter": "",
+        # We can't actually use the clipboard for these operations
+        "copyToClipboard": "y",
+        "cutToClipboard": "c",
+        "pasteFromClipboard": "y",
+
+}
+
+# This operates on a paradigm of staying in insert mode, but at least allows standard community text editing commands if the user has set their shell to vi mode in read line.
+# Vi bindings may occasionally have an issue at the start or end of a line, because the cursor may get stuck and the subsequent reentering of insert mode will leave the cursor one before the end of the line.
+@ctx.action_class("edit")
+class EditActions:
+    # Map possible edit actions to letters, run the edit action first, then modifier letter/callback
+    # def edit_command(action, modifier):
+    #     """Perform edit command"""
+    #     # count = modifier.count
+    #     actions.key("escape")
+    #     actions.insert(action.type)
+    #     actions.insert(modifier.callback)
+
+    def delete_line():
+        actions.key("escape")
+        actions.insert("cc")
+
+    def word_left():
+        actions.key("escape")
+        actions.insert("bi")
+
+    def word_right():
+        actions.key("escape")
+        # the escape key shifts the position one to the left
+        actions.key("right")
+        actions.insert("w")
+        # Unfortunately this will end up one character before the end if we have reached the last word of the line
+        actions.insert("i")
+
+    def line_end():
+        actions.key("escape")
+        actions.insert("A")
+
+    def line_start():
+        actions.key("escape")
+        actions.insert("I")
+
+    def undo():
+        # Technically control underscore works in vi readline mode as well, but this also works in zsh
+        actions.key("escape")
+        actions.insert("ua")
+
+    # TODO: we don't want to overwrite the system's paste action, should this be a separate command?
+    # def paste():
+
+    # Read line doesn't have any selection mechanism, so instead we add any "selections" to a pending selection object, which get applied when the edit next action is called
+    def extend_line_end():
+        global pendingSelection
+        pendingSelection = PendingSelection("$", "a")
+
+    def extend_line_start():
+        global pendingSelection
+        pendingSelection = PendingSelection("0", "i")
+
+    def extend_word_left():
+        global pendingSelection
+        pendingSelection = PendingSelection("b", "i")
+
+    def extend_word_right():
+        global pendingSelection
+        pendingSelection = PendingSelection("w", "i")
+
+
+
+@ctx.action_class("user")
+class Actions:
+
+    def run_action_callback(action):
+        """
+        Run a callback that applies an edit action to the selected
+        Intended for internal use and overwriting
+        """
+        action_type = action.type
+
+        if action_type in edit_action_vi_keys:
+            actions.key("escape")
+            actions.key(edit_action_vi_keys[action_type])
+        else:
+            try:
+                callback = actions.user.get_simple_action_callback(action_type)
+                callback()
+            except KeyError as ex:
+                print("readline_vi only supports simple action callbacks")
+                return
+
+        actions.insert(str(pendingSelection.count))
+        actions.insert(pendingSelection.motion)
+        actions.insert(pendingSelection.endAction)
+
+    # def run_modifier_callback(modifier: EditModifier):
+    #     """
+    #     Store pending text movement callbacks for the next action to apply to
+    #     """
+    #     count = modifier.count
+    #     modifier = actions.user.get_modifier_callback(EditModifier)
+    #     pendingSelection = PendingSelection(
+    #         modifier.callback, "", range(1, count + 1)
+    #     )
+
+    # def edit_command(action: EditAction, modifier: EditModifier):
+    #     """Perform edit command with associated modifier. Same as function in
+    #     edit command actions except calling action before modifier."""
+    #     key = (action.type, modifier.type)
+    #     count = modifier.count
+
+    #     if key in custom_callbacks:
+    #         custom_callbacks[key](action, modifier.type, count)
+    #         return
+
+    #     elif key in compound_actions:
+    #         for i in range(1, count + 1):
+    #             compound_actions[key]()
+    #         return
+
+    #     run_action_callback(action)
+    #     run_modifier_callback(modifier)
+
+    def cut_line():
+        actions.key("escape")
+        actions.insert("cc")
+
+    # def delete_word():
+    #     actions.key("escape")
+    #     actions.insert("ciw")
+
+    # def delete_word_left():
+    #     actions.key("ctrl-w")
+
+    # def delete_word_right():
+    #     actions.user.cut_word_right()
+
+    def cut_word_right():
+        actions.key("escape")
+        actions.insert("cw")
+
+    def cut_word_left():
+        actions.key("escape")
+        actions.insert("cb")
+
+    def copy_word_left():
+        actions.key("escape")
+        actions.key("right")
+        # Yanking backwards doesn't consider the current character the cursor is on, so we need to move the cursor one to the right
+        actions.insert("ybi")
+
+    def copy_word_right():
+        actions.key("escape")
+        actions.insert("ywa")
+
+    # def cut_word():
+    #     actions.key("escape")]
+    #     actions.insert("ciw")
+
+    # def copy_word():
+    #     actions.key("escape")
+    #     actions.insert("yiwa")
+
+    # def delete_word():
+    #     actions.key("escape")
+    #     actions.insert("ciw")

--- a/tags/terminal/readline_vi.py
+++ b/tags/terminal/readline_vi.py
@@ -16,31 +16,8 @@ class PendingSelection():
     count: int = 1
 
 
-# @dataclass
-# class EditModifier:
-#     type: str
-#     count: int = 1
+pendingSelection: PendingSelection | None = None
 
-@dataclass
-class EditModifierCallback:
-    modifier: str
-    callback: str
-
-
-pendingSelection: PendingSelection = None
-
-
-modifiers: dict[str, EditModifierCallback] = {
-    item.modifier: item for item in
-    [
-        EditModifierCallback("word", "iwi"),
-        EditModifierCallback("wordLeft", "bi"),
-        EditModifierCallback("wordRight", "wa"),
-        EditModifierCallback("line", "_i"),
-        EditModifierCallback("lineEnd", "$a"),
-        EditModifierCallback("lineStart", "0i"),
-    ]
-}
 
 edit_action_vi_keys: dict[str, str] = {
         "cut": "c",
@@ -64,14 +41,6 @@ def normal_cmd(keys):
 # Vi bindings may occasionally have an issue at the start or end of a line, because the cursor may get stuck and the subsequent reentering of insert mode will leave the cursor one before the end of the line.
 @ctx.action_class("edit")
 class EditActions:
-    # Map possible edit actions to letters, run the edit action first, then modifier letter/callback
-    # def edit_command(action, modifier):
-    #     """Perform edit command"""
-    #     # count = modifier.count
-    #     actions.key("escape")
-    #     actions.insert(action.type)
-    #     actions.insert(modifier.callback)
-
     def delete_line():
         normal_cmd("cc")
 
@@ -127,6 +96,7 @@ class Actions:
         Run a callback that applies an edit action to the selected
         Intended for internal use and overwriting
         """
+        global pendingSelection
         action_type = action.type
 
         if action_type in edit_action_vi_keys:
@@ -139,78 +109,29 @@ class Actions:
                 print("readline_vi only supports simple action callbacks")
                 return
 
+        if not pendingSelection:
+            print("readline_vi: No pending selection")
+            return
         actions.insert(str(pendingSelection.count))
         actions.insert(pendingSelection.motion)
         actions.insert(pendingSelection.endAction)
-
-    # def run_modifier_callback(modifier: EditModifier):
-    #     """
-    #     Store pending text movement callbacks for the next action to apply to
-    #     """
-    #     count = modifier.count
-    #     modifier = actions.user.get_modifier_callback(EditModifier)
-    #     pendingSelection = PendingSelection(
-    #         modifier.callback, "", range(1, count + 1)
-    #     )
-
-    # def edit_command(action: EditAction, modifier: EditModifier):
-    #     """Perform edit command with associated modifier. Same as function in
-    #     edit command actions except calling action before modifier."""
-    #     key = (action.type, modifier.type)
-    #     count = modifier.count
-
-    #     if key in custom_callbacks:
-    #         custom_callbacks[key](action, modifier.type, count)
-    #         return
-
-    #     elif key in compound_actions:
-    #         for i in range(1, count + 1):
-    #             compound_actions[key]()
-    #         return
-
-    #     run_action_callback(action)
-    #     run_modifier_callback(modifier)
+        pendingSelection = None
 
     def cut_line():
-        actions.key("escape")
-        actions.insert("cc")
-
-    # def delete_word():
-    #     actions.key("escape")
-    #     actions.insert("ciw")
-
-    # def delete_word_left():
-    #     actions.key("ctrl-w")
-
-    # def delete_word_right():
-    #     actions.user.cut_word_right()
+        normal_cmd("cc")
 
     def cut_word_right():
-        actions.key("escape")
-        actions.insert("cw")
+        normal_cmd("cw")
 
     def cut_word_left():
-        actions.key("escape")
-        actions.insert("cb")
+        normal_cmd("cb")
 
     def copy_word_left():
         actions.key("escape")
+        sleep(0.2)
         actions.key("right")
         # Yanking backwards doesn't consider the current character the cursor is on, so we need to move the cursor one to the right
         actions.insert("ybi")
 
     def copy_word_right():
-        actions.key("escape")
-        actions.insert("ywa")
-
-    # def cut_word():
-    #     actions.key("escape")]
-    #     actions.insert("ciw")
-
-    # def copy_word():
-    #     actions.key("escape")
-    #     actions.insert("yiwa")
-
-    # def delete_word():
-    #     actions.key("escape")
-    #     actions.insert("ciw")
+        normal_cmd("ywa")

--- a/tags/terminal/readline_vi.py
+++ b/tags/terminal/readline_vi.py
@@ -1,6 +1,7 @@
 from talon import Context, actions
 from typing import Callable
 from dataclasses import dataclass
+from time import sleep
 
 
 ctx = Context()
@@ -50,8 +51,14 @@ edit_action_vi_keys: dict[str, str] = {
         "copyToClipboard": "y",
         "cutToClipboard": "c",
         "pasteFromClipboard": "y",
-
 }
+
+def normal_cmd(keys):
+    actions.key("escape")
+    # sleep to avoid interpreting as an escape sequence
+    sleep(0.2)
+    actions.insert(keys)
+
 
 # This operates on a paradigm of staying in insert mode, but at least allows standard community text editing commands if the user has set their shell to vi mode in read line.
 # Vi bindings may occasionally have an issue at the start or end of a line, because the cursor may get stuck and the subsequent reentering of insert mode will leave the cursor one before the end of the line.
@@ -66,15 +73,14 @@ class EditActions:
     #     actions.insert(modifier.callback)
 
     def delete_line():
-        actions.key("escape")
-        actions.insert("cc")
+        normal_cmd("cc")
 
     def word_left():
-        actions.key("escape")
-        actions.insert("bi")
+        normal_cmd("bi")
 
     def word_right():
         actions.key("escape")
+        sleep(0.1)
         # the escape key shifts the position one to the left
         actions.key("right")
         actions.insert("w")
@@ -82,17 +88,14 @@ class EditActions:
         actions.insert("i")
 
     def line_end():
-        actions.key("escape")
-        actions.insert("A")
+        normal_cmd("A")
 
     def line_start():
-        actions.key("escape")
-        actions.insert("I")
+        normal_cmd("I")
 
     def undo():
         # Technically control underscore works in vi readline mode as well, but this also works in zsh
-        actions.key("escape")
-        actions.insert("ua")
+        normal_cmd("ua")
 
     # TODO: we don't want to overwrite the system's paste action, should this be a separate command?
     # def paste():
@@ -127,8 +130,7 @@ class Actions:
         action_type = action.type
 
         if action_type in edit_action_vi_keys:
-            actions.key("escape")
-            actions.key(edit_action_vi_keys[action_type])
+            normal_cmd(edit_action_vi_keys[action_type])
         else:
             try:
                 callback = actions.user.get_simple_action_callback(action_type)


### PR DESCRIPTION
Generally speaking the refactor allows you to override how edit actions are applied, which I uses to make sure that the modifier/selection applies by creating a vim motion instead of trying to select terminal text. The refactors to the edit commands are fairly minimal, it's just converting the functions into user actions and refactoring out actions to access the internal dictionaries.

In draft mode while I dog food it for a week or so to ensure it is ready