### PR TITLE
chore(docs): Normalize date formats in BREAKING_CHANGES to YYYY-MM-DD

### DIFF
--- a/BREAKING_CHANGES.txt
+++ b/BREAKING_CHANGES.txt
@@ -7,12 +7,12 @@ and when the change was applied given the delay between changes being
 submitted and the time they were reviewed and merged.
 
 ---
-* 2025-5-26 Change the `genericForLoopStatement` snippet's name to `forLoopStatement` and change the existing `forLoopStatement` snippet's name to `forRangeStatement`. `forRangeStatement` is now used with `snip for range`.
-* 2025-20-04 Deprecated php commands `(op | is) loosely equal` and `(op | is) loosely not equal` in favor of `is weak equal` and `is weak not equal`. The names of the comparison operators can be updated in lang/tags/operators_math_comparison.talon-list if desired.
+* 2025-05-26 Change the `genericForLoopStatement` snippet's name to `forLoopStatement` and change the existing `forLoopStatement` snippet's name to `forRangeStatement`. `forRangeStatement` is now used with `snip for range`.
+* 2025-04-20 Deprecated php commands `(op | is) loosely equal` and `(op | is) loosely not equal` in favor of `is weak equal` and `is weak not equal`. The names of the comparison operators can be updated in lang/tags/operators_math_comparison.talon-list if desired.
 * 2025-03-04 Deprecated javascript commands `(op | is) strict equal` and `(op | is) strict not equal` in favor of `is equal` and `is not equal`. Weak comparison can be done with `is weak equal` and `is weak not equal`.
 * 2025-02-01 Removed snippet language inheritance. From now on typescript will not automatically use javascript snippets. Each snippet need to define every language it should be active in.
 * 2025-01-19 Deprecated a bunch of programming language operator commands in favor of using Talon lists
-* 2024-12-3 Introduced an intermediate layer for naming snap window positions instead of using the raw spoken forms. Instead of calling snap_window_to_position("top right") you should now call snap_window_to_position("TOP_RIGHT")
+* 2024-12-03 Introduced an intermediate layer for naming snap window positions instead of using the raw spoken forms. Instead of calling snap_window_to_position("top right") you should now call snap_window_to_position("TOP_RIGHT")
 * 2024-12-26 Deprecated action `user.zoom_close` in favor of `tracking.zoom_cancel`.
 * 2024-11-24 Deprecated a bunch of symbol commands to insert delimited pairs
   ("", '', []) in favor of the new `delimiter_pair` Talon list file.


### PR DESCRIPTION
A few dates were missing a leading 0 or were in YYYY-DD-MM rather than the file's existing convention of YYYY-MM-DD