### PR TITLE
feat: Optional display microphone name text in mode indicator

### DIFF
--- a/plugin/mode_indicator/mode_indicator.py
+++ b/plugin/mode_indicator/mode_indicator.py
@@ -41,6 +41,7 @@ mod.setting(
     type=float,
     desc="Mode indicator gradient brightness in percentages(0-1). 0=darkest, 1=brightest",
 )
+mod.setting("mode_indicator_color_text", type=str)
 mod.setting("mode_indicator_color_mute", type=str)
 mod.setting("mode_indicator_color_sleep", type=str)
 mod.setting("mode_indicator_color_dictation", type=str)
@@ -115,6 +116,37 @@ def on_draw(c: SkiaCanvas):
     c.paint.color = color_mode
     c.draw_circle(x, y, radius)
 
+def on_draw_text(c: SkiaCanvas):
+    x, y = c.rect.center.x, c.rect.center.y
+    radius = c.rect.height / 2 - 2
+    text = actions.sound.active_microphone()[:2]
+    color = settings.get("user.mode_indicator_color_text")
+    stroke = True
+    draw_text(
+        c,
+        x,
+        y,
+        text,
+        color,
+        stroke)
+    
+
+def draw_text(
+    c: SkiaCanvas,
+    x: float,
+    y: float,
+    text: str,
+    color: str = settings.get("user.mode_indicator_color_other"),
+    stroke: bool = True,
+):
+    c.paint.style = c.paint.Style.FILL
+    c.paint.color = color
+    text_rect = c.paint.measure_text(text)[1]
+    c.draw_text(
+        text,
+        x - text_rect.x - text_rect.width / 2,
+        y - text_rect.y - text_rect.height / 2,
+    )
 
 def move_indicator():
     screen: Screen = ui.main_screen()
@@ -140,7 +172,9 @@ def move_indicator():
 def show_indicator():
     global canvas
     canvas = Canvas.from_rect(Rect(0, 0, 0, 0))
+    canvas = Canvas.from_rect(Rect(0, 0, 0, 0))
     canvas.register("draw", on_draw)
+    canvas.register("draw", on_draw_text)
 
 
 def hide_indicator():

--- a/plugin/mode_indicator/mode_indicator.talon
+++ b/plugin/mode_indicator/mode_indicator.talon
@@ -1,6 +1,8 @@
 settings():
     # Don't show mode indicator by default
     user.mode_indicator_show = false
+    # Set to true to show the first 2 letters of the mic name inside the mode indicator
+    user.show_microphone_name_in_mode_indicator = false
     # 30pixels diameter
     user.mode_indicator_size = 30
     # Center horizontally. (0=left, 0.5=center, 1=right)
@@ -11,6 +13,8 @@ settings():
     user.mode_indicator_color_alpha = 0.75
     # Grey gradient
     user.mode_indicator_color_gradient = 0.5
+    # White color for optional text overlay on mode indicator
+    user.mode_indicator_color_text = "EEE"
     # Black color for when the microphone is muted (set to "None")
     user.mode_indicator_color_mute = "000000"
     # Grey color for sleep mode


### PR DESCRIPTION
I tend to switch between my computer's onboard mic and a wireless mic fairly often, having text up inside the indicator helps me know which mic is active.

Optional display of microphone name substring in the mode indictor.

Would this be useful to others?

Looks like this:

MacBook Pro Microphone - Command mode
<img width="26" alt="image" src="https://github.com/user-attachments/assets/e9d0b306-8aae-4983-a9e2-c5876ebc4205" />
RØDE Connect Stream -  Dictation Mode
<img width="29" alt="image" src="https://github.com/user-attachments/assets/9adab021-b2cb-4b72-9b08-946d138153cc" />
None -
<img width="32" alt="image" src="https://github.com/user-attachments/assets/eba0ae04-82c7-4ee2-bacf-f6ad47e953fa" />


- Add on_draw_text to render microphone name initials inside the mode indicator
- Show active microphone's first two letters as overlay text
- Use configurable text color for microphone label
- Default to not show text