### PR TITLE
Fix error when trying to display an empty list

### DIFF
--- a/core/help/help.py
+++ b/core/help/help.py
@@ -572,8 +572,9 @@ def gui_list_help(gui: imgui.GUI):
 
     gui.line()
 
-    for key, value in pages_list[current_list_page - 1].items():
-        gui.text(f"{value}: {key}")
+    if len(pages_list) > 0:
+        for key, value in pages_list[current_list_page - 1].items():
+            gui.text(f"{value}: {key}")
 
     gui.spacer()
 


### PR DESCRIPTION
When calling help for a list which happens to be empty (ex: saying "help snip" with no global snippets and outside of a supported language mode), the command fails with "IndexError: list index out of range".