### PR TITLE
Migrate c to use for loop snippet

### DIFF
--- a/core/snippets/snippets/forLoopStatement.snippet
+++ b/core/snippets/snippets/forLoopStatement.snippet
@@ -8,14 +8,14 @@ language: scala
 for ($1) $0
 ---
 
-language: c | cpp | csharp | java | javascript | typescript | javascriptreact | typescriptreact
+language: cpp | csharp | java | javascript | typescript | javascriptreact | typescriptreact
 -
 for ($1) {
 	$0
 }
 ---
 
-language: php
+language: php | c
 -
 for ($1; $2; $3) {
 	$0

--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -265,7 +265,7 @@ class UserActions:
         actions.user.insert_snippet_by_name("caseStatement")
 
     def code_state_for():
-        actions.auto_insert("for ")
+        actions.user.insert_snippet_by_name("forLoopStatement")
 
     def code_state_go_to():
         actions.auto_insert("goto ")


### PR DESCRIPTION
This migrates c to use the for loop snippet and uses the version of the snippet with the semicolons.