### PR TITLE
Migrate lua try catch

### DIFF
--- a/core/snippets/snippets/lua.snippet
+++ b/core/snippets/snippets/lua.snippet
@@ -19,3 +19,10 @@ for ${1:k}, ${2:v} in pairs($3) do
     $0
 end
 ---
+
+name: tryCatchStatement
+phrase: try catch
+insertionScope: statement
+-
+pcall($0)
+---

--- a/lang/lua/lua.py
+++ b/lang/lua/lua.py
@@ -203,7 +203,7 @@ class UserActions:
         actions.insert("goto continue")
 
     def code_try_catch():
-        actions.user.insert_between("pcall(", ")")
+        actions.user.insert_snippet_by_name("tryCatchStatement")
 
     ##
     # code_comment_line


### PR DESCRIPTION
I put the snippet in the lua file because the try catch statement file requires 2 snippet placeholders. I was not sure how to properly convert this into a snippet due to lack of familiarity with the language, so I just recreated the functionality of the original action and will leave a proper snippet definition to someone more familiar with the language.