### PR TITLE
1 Line Bugfix: Fix missing go common function tag activation

### DIFF
--- a/lang/go/go.talon
+++ b/lang/go/go.talon
@@ -8,6 +8,7 @@ tag(): user.code_comment_block_c_like
 tag(): user.code_data_bool
 tag(): user.code_data_null
 tag(): user.code_functions
+tag(): user.code_functions_common
 tag(): user.code_libraries
 tag(): user.code_operators_array
 tag(): user.code_operators_assignment


### PR DESCRIPTION
Go had a list of common functions defined but lacked the appropriate tag activation.