### PR TITLE
Address c signed spacing

### DIFF
--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -20,8 +20,8 @@ ctx.lists["self.stdint_signed"] = {
 }
 
 ctx.lists["self.c_signed"] = {
-    "signed": "signed ",
-    "unsigned": "unsigned ",
+    "signed": "signed",
+    "unsigned": "unsigned",
 }
 
 ctx.lists["self.c_keywords"] = {

--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -78,7 +78,7 @@ standard cast to <user.stdint_cast>: "{stdint_cast}"
 <user.c_types>: "{c_types}"
 <user.c_pointers>: "{c_pointers}"
 <user.c_keywords>: "{c_keywords}"
-<user.c_signed>: "{c_signed}"
+<user.c_signed>: "{c_signed} "
 standard <user.stdint_types>: "{stdint_types}"
 int main: user.insert_between("int main(", ")")
 


### PR DESCRIPTION
I attempt to address at least part of this issue: https://github.com/talonhub/community/issues/853. The c_signed list had the issue of having spaces at the end of its words, which would create an extra space when used by captures not expecting that. I addressed this by removing the extraneous spaces and adding a space at the end of the command consisting solely of the c_signed capture. 
I have not done c programming in ages, so I would appreciate it if someone actually using this grammar could test to see if this breaks anything before it gets merged.