### PR TITLE
Remove duplicate c_types capture definition

### DIFF
--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -152,13 +152,6 @@ def c_keywords(m) -> str:
     "Returns a string"
     return m.c_keywords
 
-
-@mod.capture(rule="{self.c_types}")
-def c_types(m) -> str:
-    "Returns a string"
-    return m.c_types
-
-
 @mod.capture(rule="{self.c_types}")
 def c_types(m) -> str:
     "Returns a string"

--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -152,6 +152,7 @@ def c_keywords(m) -> str:
     "Returns a string"
     return m.c_keywords
 
+
 @mod.capture(rule="{self.c_types}")
 def c_types(m) -> str:
     "Returns a string"


### PR DESCRIPTION
The definition of the c_types capture had an exact duplicate, so this PR removes it. 