### PR TITLE
Migrate block to snippets

### DIFF
--- a/core/snippets/snippets/codeBlock.snippet
+++ b/core/snippets/snippets/codeBlock.snippet
@@ -1,0 +1,23 @@
+name: codeBlock
+phrase: block
+---
+
+language: c | cpp | csharp | java | javascript | typescript | javascriptreact | typescriptreact | php | scala | kotlin | r | rust | go | css | terraform | protobuf
+-
+{
+    $0
+}
+---
+
+language: python
+-
+:
+    $0
+---
+
+language: stata
+-
+
+
+$0
+---

--- a/core/snippets/snippets/codeBlock.snippet
+++ b/core/snippets/snippets/codeBlock.snippet
@@ -2,7 +2,7 @@ name: codeBlock
 phrase: block
 ---
 
-language: c | cpp | csharp | java | javascript | typescript | javascriptreact | typescriptreact | php | scala | kotlin | r | rust | go | css | terraform | protobuf
+language: c | cpp | csharp | java | javascript | typescript | javascriptreact | typescriptreact | php | scala | kotlin | r | rust | go | css | scss | terraform | protobuf
 -
 {
     $0

--- a/lang/stata/stata.py
+++ b/lang/stata/stata.py
@@ -87,10 +87,6 @@ class UserActions:
             substitutions["0"] = selection
         actions.user.insert_snippet_by_name("functionCall", substitutions)
 
-    # imperative.py
-    def code_block():
-        actions.auto_insert("\n")
-
     # libraries.py
     def code_insert_library(text: str, selection: str):
         library_text = text + selection

--- a/lang/tags/imperative.py
+++ b/lang/tags/imperative.py
@@ -18,6 +18,7 @@ tag: user.code_block_c_like
 class Actions:
     def code_block():
         """Inserts equivalent of {\n} for the active language, and places the cursor appropriately"""
+        actions.user.insert_snippet_by_name("codeBlock")
 
     def code_state_if():
         """Inserts if statement"""
@@ -79,9 +80,3 @@ class Actions:
         """Inserts try/catch. If selection is true, does so around the selection"""
         actions.user.insert_snippet_by_name("tryCatchStatement")
 
-
-@c_like_ctx.action_class("user")
-class CActions:
-    def code_block():
-        actions.user.insert_between("{", "}")
-        actions.key("enter")

--- a/lang/tags/imperative.py
+++ b/lang/tags/imperative.py
@@ -1,6 +1,5 @@
 from talon import Context, Module, actions
 
-c_like_ctx = Context()
 mod = Module()
 
 mod.tag(
@@ -8,11 +7,6 @@ mod.tag(
     desc="Tag for enabling basic imperative programming commands (loops, functions, etc)",
 )
 mod.tag("code_block_c_like", desc="Language uses C style code blocks, i.e. braces")
-
-c_like_ctx.matches = """
-tag: user.code_block_c_like
-"""
-
 
 @mod.action_class
 class Actions:


### PR DESCRIPTION
This raises the question of what to do with the code_block_c_like tag.

I think we can leave it as users might have made use of it in their custom repositories, but I think it should be moved out of imperative.