### PR TITLE
Fix ruby state do

### DIFF
--- a/lang/ruby/ruby.talon
+++ b/lang/ruby/ruby.talon
@@ -32,6 +32,7 @@ state end: "end"
 state begin: "begin"
 state rescue: "rescue "
 state module: "module "
+state do: user.code_state_do()
 
 ^instance <user.text>$:
     insert("@")


### PR DESCRIPTION
This is a temporary fix until we can decide on something better.

Ruby used code state do for something other than do while loops, so it did not get covered in the snippet migration.

I am not sure why my migration pull request got merged before we figured out what to do with this. I guess I can try to be more clear with my comments going forward.