### PR TITLE
Add wait option to `insert_between` action

### DIFF
--- a/core/edit/insert_between.py
+++ b/core/edit/insert_between.py
@@ -1,12 +1,20 @@
-from talon import Module, actions
+from time import sleep
+from talon import Module, actions, settings
 
 mod = Module()
 
+mod.setting(
+    "insert_between_wait",
+    type=int,
+    default=0,
+    desc="Time in milliseconds to sleep after inserting text with `insert_between` (e.g. when using paired delimiters like 'box' or 'round'), before moving the cursor back. Useful to set on a per-application basis, to prevent moving the moving the cursor before text is inserted",
+)
 
 @mod.action_class
 class module_actions:
     def insert_between(before: str, after: str):
         """Insert `before + after`, leaving cursor between `before` and `after`. Not entirely reliable if `after` contains newlines."""
         actions.insert(f"{before}{after}")
+        sleep(int(settings.get("user.insert_between_wait", 0)) / 1000)
         for _ in after:
             actions.edit.left()

--- a/settings.talon
+++ b/settings.talon
@@ -1,4 +1,4 @@
-settings():
+:
     # Adjust the scale of the imgui
     imgui.scale = 1.3
 
@@ -102,6 +102,9 @@ settings():
 
     # Time in seconds to wait for the clipboard to change when trying to get selected text
     # user.selected_text_timeout = 0.25
+
+    # Time in milliseconds to sleep after inserting text with `insert_between` (e.g. when using paired delimiters like 'box' or 'round'), before moving the cursor back. Useful to set on a per-application basis, to prevent moving the moving the cursor before text is inserted.
+    # insert_between_wait = 0
 
 # Uncomment to enable the curse yes/curse no commands (show/hide mouse cursor).
 # See issue #688 for more detail: https://github.com/talonhub/community/issues/688


### PR DESCRIPTION
Allows users to fix issues like paired delimiter insertion always failing in VSCode, without having to have an incredibly long insert or key wait