### PR TITLE
Improve list help display

### DIFF
--- a/core/help/help.py
+++ b/core/help/help.py
@@ -663,6 +663,7 @@ def gui_list_help(gui: imgui.GUI):
 
     gui.text(f"List: {selected_list} ({page_info})")
 
+    # Extract description from list declaration, i.e. mod.list(..., desc=...))
     if (desc := registry.decls.lists[selected_list].desc) is not None:
         for line in wrap(desc):
             gui.text(line)

--- a/core/help/help.py
+++ b/core/help/help.py
@@ -3,6 +3,7 @@ import math
 import re
 from collections import defaultdict
 from itertools import islice
+from textwrap import wrap
 from typing import Any, Iterable, Tuple
 
 from talon import Context, Module, actions, imgui, registry, settings
@@ -655,7 +656,16 @@ def gui_list_help(gui: imgui.GUI):
     total_page_count = len(pages_list)
     # print(pages_list[current_page])
 
-    gui.text(f"{selected_list} {current_list_page}/{total_page_count}")
+    if total_page_count == 0:
+        page_info = "empty"
+    else:
+        page_info = f"{current_list_page}/{total_page_count}"
+
+    gui.text(f"List: {selected_list} ({page_info})")
+
+    if (desc := registry.decls.lists[selected_list].desc) is not None:
+        for line in wrap(desc):
+            gui.text(line)
 
     gui.line()
 


### PR DESCRIPTION
- Display "List: " at the beginning and pagination in parentheses to match other help displays
- Display the list description (wrapped to 70 characters if needed)
- Display "empty" instead of "1/0" if the list is empty

Before:
<img width="95" height="521" alt="image" src="https://github.com/user-attachments/assets/8caa4153-ddd5-4b2d-a508-085e7fd87e15" />

After:
<img width="225" height="631" alt="image" src="https://github.com/user-attachments/assets/5dc45786-43c6-46dc-92c8-15694949b974" />
