### PR TITLE
Provide c++ operators definition

### DIFF
--- a/lang/c++/c++.py
+++ b/lang/c++/c++.py
@@ -1,0 +1,15 @@
+from talon import Module, Context
+
+from ..c.c import operators
+from ..tags.operators import Operators
+
+ctx = Context()
+
+ctx.matches = r"""
+code.language: cpp
+"""
+
+@ctx.action_class("user")
+class UserActions:
+	def code_get_operators() -> Operators:
+		return operators

--- a/lang/c++/c++.talon
+++ b/lang/c++/c++.talon
@@ -1,0 +1,8 @@
+code.language: cpp
+-
+
+tag(): user.code_operators_array
+tag(): user.code_operators_assignment
+tag(): user.code_operators_bitwise
+tag(): user.code_operators_math
+tag(): user.code_operators_pointer


### PR DESCRIPTION
We can just use the c operators. 

I wanted to work on c++ support one feature at a time as the larger pull requests adding support for the entire language in one go seem to consistently lose momentum. It is worth discussing if we should put support for the language in a separate file. I personally think so to improve organization. We can use talon constructs and importing to reuse relevant pieces of the c implementation anyways.