### PR TITLE
Add alternative for unsigned

### DIFF
--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -17,6 +17,7 @@ ctx.lists["self.c_pointers"] = {
 ctx.lists["self.stdint_signed"] = {
     "signed": "",
     "unsigned": "u",
+    "you": "u",
 }
 
 ctx.lists["self.c_signed"] = {


### PR DESCRIPTION
This can be tested with the following c.talon command: standard cast to <user.stdint_cast>: "{stdint_cast}"
example: `static cast to you int` gives `(uint32_t)`
Another change based on chdoc's c++ pull request.