### PR TITLE
[Quick Fix] Fix snippet stop replacements

### DIFF
--- a/core/snippets/snippets/functionCall.snippet
+++ b/core/snippets/snippets/functionCall.snippet
@@ -1,15 +1,15 @@
 name: functionCall
 phrase: call
 insertionScope: statement
-
-$0.wrapperPhrase: call
 ---
 
 language: c | cpp | csharp | python | talon | java | javascript | typescript | javascriptreact | typescriptreact | css | scss | sql | r
+$2.wrapperPhrase: call
 -
-$1($0)
+$1($2)
 ---
 
+$0.wrapperPhrase: call
 language: stata
 -
 $1 $0

--- a/core/snippets/snippets/functionCall.snippet
+++ b/core/snippets/snippets/functionCall.snippet
@@ -9,8 +9,8 @@ $2.wrapperPhrase: call
 $1($2)
 ---
 
-$0.wrapperPhrase: call
 language: stata
+$0.wrapperPhrase: call
 -
 $1 $0
 ---

--- a/core/snippets/snippets/import.snippet
+++ b/core/snippets/snippets/import.snippet
@@ -15,7 +15,7 @@ import $0
 
 language: lua
 -
-local $1 = require('$0')
+local $1 = require('$2')
 ---
 
 language: ruby
@@ -30,12 +30,12 @@ import $0;
 
 language: php | rust
 -
-use $0;
+use $1;
 ---
 
 language: r
 -
-library($0)
+library($1)
 ---
 
 language: stata

--- a/lang/css/css.py
+++ b/lang/css/css.py
@@ -77,5 +77,5 @@ class UserActions:
     def code_insert_function(text: str, selection: str):
         substitutions = {"1": text}
         if selection:
-            substitutions["0"] = selection
+            substitutions["2"] = selection
         actions.user.insert_snippet_by_name("functionCall", substitutions)

--- a/lang/lua/lua.py
+++ b/lang/lua/lua.py
@@ -193,4 +193,5 @@ class UserActions:
     def code_insert_library(text: str, selection: str):
         substitutions = {"1": selection, "2": selection}
         actions.user.insert_snippet_by_name("importStatement", substitutions)
+
     # non-tag related actions

--- a/lang/lua/lua.py
+++ b/lang/lua/lua.py
@@ -191,7 +191,6 @@ class UserActions:
     # code_libraries
     ##
     def code_insert_library(text: str, selection: str):
-        substitutions = {"1": selection, "0": selection}
+        substitutions = {"1": selection, "2": selection}
         actions.user.insert_snippet_by_name("importStatement", substitutions)
-
     # non-tag related actions

--- a/lang/r/r.py
+++ b/lang/r/r.py
@@ -145,7 +145,7 @@ class UserActions:
         actions.edit.left()
 
     def code_insert_library(text: str, selection: str):
-        actions.user.insert_snippet_by_name("importStatement", {"0": text + selection})
+        actions.user.insert_snippet_by_name("importStatement", {"1": text + selection})
 
     def code_insert_named_argument(parameter_name: str):
         actions.insert(f"{parameter_name} = ")

--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -340,7 +340,7 @@ class UserActions:
     # tag: libraries
 
     def code_insert_library(text: str, selection: str):
-        actions.user.insert_snippet_by_name("importStatement", {"0": text})
+        actions.user.insert_snippet_by_name("importStatement", {"1": text})
 
     # rust specific grammar
 

--- a/lang/sql/sql.py
+++ b/lang/sql/sql.py
@@ -42,5 +42,5 @@ class UserActions:
     def code_insert_function(text: str, selection: str):
         substitutions = {"1": text}
         if selection:
-            substitutions["0"] = selection
+            substitutions["2"] = selection
         actions.user.insert_snippet_by_name("functionCall", substitutions)


### PR DESCRIPTION
The decision to insert $0 at the end of snippets has messed with snippet replacements involving $0. This should fix all of them.
For a longer term fix, I recommend we stop changing the snippet when loading it and instead have an action that changes the snippet during insertion after making replacements.