### PR TITLE
[Quick Fix] Do temporary fix given replacement issue

### DIFF
--- a/lang/css/css.py
+++ b/lang/css/css.py
@@ -77,5 +77,5 @@ class UserActions:
     def code_insert_function(text: str, selection: str):
         substitutions = {"1": text}
         if selection:
-            substitutions["0"] = selection
+            substitutions["2"] = selection
         actions.user.insert_snippet_by_name("functionCall", substitutions)

--- a/lang/lua/lua.py
+++ b/lang/lua/lua.py
@@ -191,7 +191,7 @@ class UserActions:
     # code_libraries
     ##
     def code_insert_library(text: str, selection: str):
-        substitutions = {"1": selection, "0": selection}
+        substitutions = {"1": selection, "2": selection}
         actions.user.insert_snippet_by_name("importStatement", substitutions)
 
     # non-tag related actions

--- a/lang/r/r.py
+++ b/lang/r/r.py
@@ -145,7 +145,7 @@ class UserActions:
         actions.edit.left()
 
     def code_insert_library(text: str, selection: str):
-        actions.user.insert_snippet_by_name("importStatement", {"0": text + selection})
+        actions.user.insert_snippet_by_name("importStatement", {"1": text + selection})
 
     def code_insert_named_argument(parameter_name: str):
         actions.insert(f"{parameter_name} = ")

--- a/lang/rust/rust.py
+++ b/lang/rust/rust.py
@@ -340,7 +340,7 @@ class UserActions:
     # tag: libraries
 
     def code_insert_library(text: str, selection: str):
-        actions.user.insert_snippet_by_name("importStatement", {"0": text})
+        actions.user.insert_snippet_by_name("importStatement", {"1": text})
 
     # rust specific grammar
 

--- a/lang/sql/sql.py
+++ b/lang/sql/sql.py
@@ -42,5 +42,5 @@ class UserActions:
     def code_insert_function(text: str, selection: str):
         substitutions = {"1": text}
         if selection:
-            substitutions["0"] = selection
+            substitutions["2"] = selection
         actions.user.insert_snippet_by_name("functionCall", substitutions)


### PR DESCRIPTION
The decision to insert $0 at the end of snippets has messed with snippet replacements involving $0. This should fix all of them.
For a longer term fix, I recommend we stop changing the snippet when loading it and instead have an action that changes the snippet during insertion after making replacements.