### PR TITLE
cpp draft object oriented support

### DIFF
--- a/lang/cpp/cpp.py
+++ b/lang/cpp/cpp.py
@@ -1,4 +1,4 @@
-from talon import Context, Module
+from talon import Context, Module, actions
 
 from ..c.c import operators
 from ..tags.operators import Operators
@@ -24,6 +24,15 @@ def cpp_standard_type(m) -> str:
 class UserActions:
     def code_get_operators() -> Operators:
         return operators
+
+    def code_operator_object_accessor():
+        actions.insert(".")
+
+    def code_self():
+        actions.insert("this")
+
+    def code_self_accessor():
+        actions.insert("(*this).")
 
 
 @ctx.capture("user.code_type", rule="<user.c_types> | <user.cpp_standard_type>")

--- a/lang/cpp/cpp.talon
+++ b/lang/cpp/cpp.talon
@@ -6,6 +6,7 @@ tag(): user.code_operators_assignment
 tag(): user.code_operators_bitwise
 tag(): user.code_operators_math
 tag(): user.code_operators_pointer
+tag(): user.code_object_oriented
 
 # e.g. "stood vector"
 # To allow more easily dealing with generic types, a future update might include the number of generic type arguments in the string returned by the cpp_standard_type capture
@@ -13,3 +14,6 @@ tag(): user.code_operators_pointer
 
 #The default tag for this is for function support, so this is explicitly defined here until full function support is provided
 type <user.code_type>: insert(code_type)
+
+self arrow: insert("this->")
+(star | dereference) self: insert("*this")

--- a/lang/tags/object_oriented.py
+++ b/lang/tags/object_oriented.py
@@ -19,6 +19,11 @@ class Actions:
     def code_self():
         """Inserts a reference to the current object (e.g., C++ "this" or Python's "self")"""
 
+    def code_self_accessor():
+        """Inserts the object accessor applied to a reference to the current object (e.g., python's "self.")"""
+        actions.user.code_self()
+        actions.user.code_operator_object_accessor()
+
     def code_define_class():
         """Starts a class definition (e.g., Java's "class" keyword)"""
         actions.user.insert_snippet_by_name("classDeclaration")

--- a/lang/tags/object_oriented.talon
+++ b/lang/tags/object_oriented.talon
@@ -1,9 +1,7 @@
 tag: user.code_object_oriented
 -
 
-self dot:
-    user.code_self()
-    user.code_operator_object_accessor()
+self dot: user.code_self_accessor()
 
 state self: user.code_self()
 


### PR DESCRIPTION
This is a little complicated by accessing self in C++ being `this->` or `*(this).` instead of `this.`, but the standard command is `self dot`. I made questionable choices to accommodate the existing spoken form and the different things you do with `this` in C++.

I made `self dot` do `*(this).` to be consistent with the name of the command while actually accessing the object properly. I made `self dot` now use an overwritable action that defaults to the prior behavior. 

I added custom actions for C++ based on common ways to interact with the `this` keyword. 

```talon
self arrow: insert("this->")
(star | dereference) self: insert("*this")
```

@chdoc do you think this is a reasonable way to handle this? Do you have alternative suggestions?