### PR TITLE
C++ support: base types, standard functions and heater files, namespaces

### DIFF
--- a/lang/c/c.py
+++ b/lang/c/c.py
@@ -1,3 +1,4 @@
+from contextlib import suppress
 from talon import Context, Module, actions, settings
 
 from ...core.described_functions import create_described_insert_between
@@ -27,6 +28,13 @@ c_and_cpp_ctx.lists["self.stdint_signed"] = {
     "you": "u",
 }
 
+c_and_cpp_ctx.lists["self.c_type_bit_width"] = {
+    "eight": "8",
+    "sixteen": "16",
+    "thirty two": "32",
+    "sixty four": "64",
+}
+
 c_and_cpp_ctx.lists["self.c_signed"] = {
     "signed": "signed",
     "unsigned": "unsigned",
@@ -54,15 +62,18 @@ c_and_cpp_ctx.lists["self.c_types"] = {
     "char": "char",
     "short": "short",
     "long": "long",
+    "long long": "long long",
     "int": "int",
     "integer": "int",
     "void": "void",
     "double": "double",
+    "long double": "long double",
     "struct": "struct",
     "struck": "struct",
     "num": "enum",
     "union": "union",
     "float": "float",
+    "size tea": "size_t",
 }
 
 ctx.lists["user.code_libraries"] = {
@@ -90,6 +101,16 @@ mod.list("c_signed", desc="Common C datatype signed modifiers")
 mod.list("c_types", desc="Common C types")
 mod.list("stdint_types", desc="Common stdint C types")
 mod.list("stdint_signed", desc="Common stdint C datatype signed modifiers")
+mod.list("c_type_bit_width", desc="Common C type bit widths")
+
+# capture explicitly referenced from the C++ files
+@mod.capture(rule="(fix|fixed) [{self.stdint_signed}] [int] {self.c_type_bit_width}")
+def c_fixed_integer(m) -> str:
+    """fixed-width integer types (e.g. "uint32_t")"""
+    prefix = ""
+    with suppress(AttributeError):
+        prefix = m.stdint_signed
+    return prefix + "int" + m.c_type_bit_width + "_t"
 
 
 @mod.capture(rule="{self.c_pointers}")
@@ -97,13 +118,13 @@ def c_pointers(m) -> str:
     "Returns a string"
     return m.c_pointers
 
-
+# capture explicitly referenced from the C++ files
 @mod.capture(rule="{self.c_signed}")
 def c_signed(m) -> str:
     "Returns a string"
     return m.c_signed
 
-
+# capture explicitly referenced from the C++ files
 @mod.capture(rule="{self.c_types}")
 def c_types(m) -> str:
     "Returns a string"

--- a/lang/c/c.talon
+++ b/lang/c/c.talon
@@ -78,6 +78,7 @@ standard cast to <user.stdint_cast>: "{stdint_cast}"
 <user.c_types>: "{c_types}"
 <user.c_pointers>: "{c_pointers}"
 <user.c_signed>: "{c_signed} "
+<user.c_fixed_integer>: "{c_fixed_integer}"
 standard <user.stdint_types>: "{stdint_types}"
 int main: user.insert_between("int main(", ")")
 

--- a/lang/cpp/code_common_function.talon-list
+++ b/lang/cpp/code_common_function.talon-list
@@ -1,0 +1,11 @@
+list: user.code_common_function
+code.language: cpp
+-
+mem copy: memcpy
+mem set: memset
+print eff: printf
+es print eff: sprintf
+es en print eff: sprintf
+ay to eye: atoi
+size of: sizeof
+exit: exit

--- a/lang/cpp/cpp.py
+++ b/lang/cpp/cpp.py
@@ -1,4 +1,5 @@
-from talon import Context, Module
+from contextlib import suppress
+from talon import Context, Module, actions
 
 from ..c.c import operators
 from ..tags.operators import Operators
@@ -10,6 +11,14 @@ ctx.matches = r"""
 code.language: cpp
 """
 
+ctx.lists["self.cpp_pointers"] = {
+    "pointer": "*",
+    "reference": "&",
+    "ref": "&",
+    "array": "[]",
+}
+
+mod.list("cpp_pointers", desc="C++ pointer and reference annotations")
 mod.list("cpp_standard_type", desc="Types from the C++ standard library")
 mod.list("cpp_standard_prefix", desc="Prefixes for referring to the standard library")
 
@@ -25,7 +34,22 @@ class UserActions:
     def code_get_operators() -> Operators:
         return operators
 
+@mod.capture(rule="([<user.c_signed>] <user.c_types>) | <user.c_fixed_integer> | <user.cpp_standard_type>")
+def code_type_raw(m) -> str:
+    return " ".join(list(m))
 
-@ctx.capture("user.code_type", rule="<user.c_types> | <user.cpp_standard_type>")
+@mod.capture(rule="<user.code_type_raw> [{user.cpp_pointers}+] <user.text>")
+def variable_declaration(m) -> str:
+    suffix = ""
+    with suppress(AttributeError):
+        suffix = "".join(m.cpp_pointers_list)
+    return m.code_type_raw+" "+suffix+actions.user.formatted_text(m.text, "SNAKE_CASE")
+ 
+
+@ctx.capture("user.code_type", rule="<user.code_type_raw> [{user.cpp_pointers}+]")
 def code_type(m):
-    return m[0]
+    """Returns a type with pointer or reference annotations"""
+    suffix = ""
+    with suppress(AttributeError):
+        suffix = "".join(m.cpp_pointers_list)
+    return m.code_type_raw+suffix

--- a/lang/cpp/cpp.py
+++ b/lang/cpp/cpp.py
@@ -23,6 +23,7 @@ mod.list("cpp_standard_type", desc="Types from the C++ standard library")
 mod.list("cpp_standard_function", desc="Functions in the std namespace")
 mod.list("cpp_standard_constant", desc="Constants in the std namespace")
 mod.list("cpp_standard_prefix", desc="Prefixes for referring to the standard library")
+mod.list("cpp_standard_header", desc="Header files of the C++ standard library")
 
 
 @mod.capture(rule="{user.cpp_standard_prefix} {user.cpp_standard_type}")

--- a/lang/cpp/cpp.py
+++ b/lang/cpp/cpp.py
@@ -24,6 +24,7 @@ mod.list("cpp_standard_function", desc="Functions in the std namespace")
 mod.list("cpp_standard_constant", desc="Constants in the std namespace")
 mod.list("cpp_standard_prefix", desc="Prefixes for referring to the standard library")
 mod.list("cpp_standard_header", desc="Header files of the C++ standard library")
+mod.list("cpp_namespace", desc="Spoken forms for C++ namespaces")
 
 
 @mod.capture(rule="{user.cpp_standard_prefix} {user.cpp_standard_type}")
@@ -40,6 +41,11 @@ def cpp_standard_function(m) -> str:
 def cpp_standard_constant(m) -> str:
     # Discard the prefix word and insert properly prefixed function call
     return "std::" + m[1]
+
+@mod.capture(rule="{user.cpp_namespace}+")
+def cpp_namespace_list(m) -> str:
+    """List of namespaces followed by colons"""
+    return "::".join(m) + "::"
 
 
 @ctx.action_class("user")

--- a/lang/cpp/cpp.py
+++ b/lang/cpp/cpp.py
@@ -20,6 +20,8 @@ ctx.lists["self.cpp_pointers"] = {
 
 mod.list("cpp_pointers", desc="C++ pointer and reference annotations")
 mod.list("cpp_standard_type", desc="Types from the C++ standard library")
+mod.list("cpp_standard_function", desc="Functions in the std namespace")
+mod.list("cpp_standard_constant", desc="Constants in the std namespace")
 mod.list("cpp_standard_prefix", desc="Prefixes for referring to the standard library")
 
 
@@ -28,11 +30,28 @@ def cpp_standard_type(m) -> str:
     # Discard the prefix word and properly prefix the type
     return "std::" + m[1]
 
+@mod.capture(rule="{user.cpp_standard_prefix} {user.cpp_standard_function}")
+def cpp_standard_function(m) -> str:
+    # Discard the prefix word and insert properly prefixed function call
+    return "std::" + m[1]
+
+@mod.capture(rule="{user.cpp_standard_prefix} {user.cpp_standard_constant}")
+def cpp_standard_constant(m) -> str:
+    # Discard the prefix word and insert properly prefixed function call
+    return "std::" + m[1]
+
 
 @ctx.action_class("user")
 class UserActions:
     def code_get_operators() -> Operators:
         return operators
+
+    def code_insert_function(text: str, selection: str):
+        substitutions = {"1": text}
+        if selection:
+            substitutions["0"] = selection
+        actions.user.insert_snippet_by_name("functionCall", substitutions)
+
 
 @mod.capture(rule="([<user.c_signed>] <user.c_types>) | <user.c_fixed_integer> | <user.cpp_standard_type>")
 def code_type_raw(m) -> str:

--- a/lang/cpp/cpp.talon
+++ b/lang/cpp/cpp.talon
@@ -23,3 +23,9 @@ type <user.code_type>: insert(code_type)
 # example: "var stood string reference full name" -> "std::string &full_name"
 var <user.variable_declaration>: insert(variable_declaration)
 
+# We reserve use of the "import" command from the user.code_libraries tag for use with C++ modules.
+include {user.cpp_standard_header}:
+    user.insert_snippet_by_name_with_phrase("includeSystemStatement", user.cpp_standard_header)
+    key(enter)
+include system: user.insert_snippet_by_name("includeSystemStatement")
+include local: user.insert_snippet_by_name("includeLocalStatement")

--- a/lang/cpp/cpp.talon
+++ b/lang/cpp/cpp.talon
@@ -13,3 +13,8 @@ tag(): user.code_operators_pointer
 
 #The default tag for this is for function support, so this is explicitly defined here until full function support is provided
 type <user.code_type>: insert(code_type)
+
+# usage: type name followed by variable name
+# example: "var stood string reference full name" -> "std::string &full_name"
+var <user.variable_declaration>: insert(variable_declaration)
+

--- a/lang/cpp/cpp.talon
+++ b/lang/cpp/cpp.talon
@@ -6,10 +6,15 @@ tag(): user.code_operators_assignment
 tag(): user.code_operators_bitwise
 tag(): user.code_operators_math
 tag(): user.code_operators_pointer
+tag(): user.code_functions_common
 
 # e.g. "stood vector"
 # To allow more easily dealing with generic types, a future update might include the number of generic type arguments in the string returned by the cpp_standard_type capture
 <user.cpp_standard_type>: insert(cpp_standard_type)
+<user.cpp_standard_constant>: insert(cpp_standard_constant)
+
+[funk] <user.cpp_standard_function>: user.code_insert_function(cpp_standard_function, "")
+funk wrap <user.cpp_standard_function>: user.code_insert_function(cpp_standard_function, edit.selected_text())
 
 #The default tag for this is for function support, so this is explicitly defined here until full function support is provided
 type <user.code_type>: insert(code_type)

--- a/lang/cpp/cpp.talon
+++ b/lang/cpp/cpp.talon
@@ -13,6 +13,8 @@ tag(): user.code_functions_common
 <user.cpp_standard_type>: insert(cpp_standard_type)
 <user.cpp_standard_constant>: insert(cpp_standard_constant)
 
+from <user.cpp_namespace_list>: insert(cpp_namespace_list)
+
 [funk] <user.cpp_standard_function>: user.code_insert_function(cpp_standard_function, "")
 funk wrap <user.cpp_standard_function>: user.code_insert_function(cpp_standard_function, edit.selected_text())
 

--- a/lang/cpp/cpp_namespace.talon-list
+++ b/lang/cpp/cpp_namespace.talon-list
@@ -1,0 +1,24 @@
+list: user.cpp_namespace
+code.language: cpp
+-
+stood: std
+standard: std
+boost
+ranges
+chrono
+filesystem
+literals
+placeholders
+regex
+this thread: this_thread
+experimental
+polymorphic: pmr
+views
+a sink I O: asio
+format: fmt
+J son: json
+thread
+atomic
+memory
+algorithm
+

--- a/lang/cpp/cpp_standard_constant.talon-list
+++ b/lang/cpp/cpp_standard_constant.talon-list
@@ -1,0 +1,7 @@
+list: user.cpp_standard_constant
+code.language: cpp
+language: en
+-
+end line: endl
+see in: cin
+see out: cout

--- a/lang/cpp/cpp_standard_function.talon-list
+++ b/lang/cpp/cpp_standard_function.talon-list
@@ -1,0 +1,117 @@
+list: user.cpp_standard_function
+code.language: cpp
+-
+all of: all_of
+any of: any_of
+apply
+as const: as_const
+async
+at
+atomic compare exchange: atomic_compare_exchange
+atomic fetch add: atomic_fetch_add
+atomic fetch sub: atomic_fetch_sub
+atomic load: atomic_load
+atomic store: atomic_store
+binary search: binary_search
+const begin: cbegin
+const end: cend
+clamp
+copy
+copy backward: copy_backward
+count
+count if: count_if
+const reverse begin: crbegin
+const reverse end: crend
+current exception: current_exception
+distance
+emplace
+emplace back: emplace_back
+emplace front: emplace_front
+end
+equal
+erase
+erase if: erase_if
+exit
+fill
+fill n: fill_n
+find
+find end: find_end
+find first of: find_first_of
+find if: find_if
+find if not: find_if_not
+for each: for_each
+format
+forward
+forward as tuple: forward_as_tuple
+generate
+generate n: generate_n
+get
+includes
+inplace merge: inplace_merge
+invoke
+is heap: is_heap
+is heap until: is_heap_until
+is partitioned: is_partitioned
+is sorted: is_sorted
+is sorted until: is_sorted_until
+iter swap: iter_swap
+lexicographical compare: lexicographical_compare
+lower bound: lower_bound
+make heap: make_heap
+make pair: make_pair
+make shared: make_shared
+make tuple: make_tuple
+make unique: make_unique
+max
+max element: max_element
+merge
+min
+min element: min_element
+minmax
+minmax element: minmax_element
+move
+next permutation: next_permutation
+none of: none_of
+nth element: nth_element
+partial sort: partial_sort
+partial sort copy: partial_sort_copy
+partition
+partition copy: partition_copy
+pop heap: pop_heap
+previous permutation: prev_permutation
+push heap: push_heap
+ranges all of: ranges::all_of
+ranges begin: ranges::begin
+ranges binary search: ranges::binary_search
+ranges end: ranges::end
+ranges reverse: ranges::reverse
+ranges sort: ranges::sort
+reduce
+remove
+remove copy: remove_copy
+remove copy if: remove_copy_if
+remove if: remove_if
+replace
+replace copy: replace_copy
+replace copy if: replace_copy_if
+replace if: replace_if
+reverse
+reverse copy: reverse_copy
+rotate
+rotate copy: rotate_copy
+search
+search n: search_n
+set difference: set_difference
+set intersection: set_intersection
+set symmetric difference: set_symmetric_difference
+set union: set_union
+set width: setw
+sort
+stable partition: stable_partition
+stable sort: stable_sort
+swap
+swap ranges: swap_ranges
+transform
+unique
+unique copy: unique_copy
+upper bound: upper_bound

--- a/lang/cpp/cpp_standard_header.talon-list
+++ b/lang/cpp/cpp_standard_header.talon-list
@@ -1,0 +1,101 @@
+list: user.cpp_standard_header
+code.language: cpp
+-
+algorithm
+any
+array
+atomic
+barrier
+bit
+bitset
+char conv: charconv
+chrono
+compare
+complex
+concepts
+condition variable: condition_variable
+contracts
+coroutine
+see stood int: cstdint
+see standard int: cstdint
+debugging
+deck: deque
+exception
+execution
+expected
+filesystem
+flat map: flat_map
+flat set: flat_set
+format
+forward list: forward_list
+F stream: fstream
+functional
+future
+generator
+hazard pointer: hazard_pointer
+hive
+initializer list: initializer_list
+inplace vector: inplace_vector
+in out manip: iomanip
+in out: ios
+in out forward: iosfwd
+I O stream: iostream
+in out stream: iostream
+in stream: istream
+iterator
+latch
+limits
+linear algebra: linalg
+list
+locale
+map
+M D span: mdspan
+memory
+memory resource: memory_resource
+mutex
+new
+numbers
+numeric
+optional
+out stream: ostream
+print
+queue
+random
+ranges
+ratio
+R C U: rcu
+regex
+scoped allocator: scoped_allocator
+semaphore
+set
+shared mutex: shared_mutex
+sim D: simd
+source location: source_location
+span
+span stream: spanstream
+string stream: sstream
+stack
+stack trace: stacktrace
+stood except: stdexcept
+standard except: stdexcept
+stood float: stdfloat
+standard float: stdfloat
+stop token: stop_token
+stream buffer: streambuf
+string
+string view: string_view
+sync stream: syncstream
+system error: system_error
+text encoding: text_encoding
+thread
+tuple
+type traits: type_traits
+type index: typeindex
+type info: typeinfo
+unordered map: unordered_map
+unordered set: unordered_set
+utility
+val array: valarray
+variant
+vector
+version

--- a/lang/cpp/cpp_standard_prefix.talon-list
+++ b/lang/cpp/cpp_standard_prefix.talon-list
@@ -1,6 +1,5 @@
 list: user.cpp_standard_prefix
 code.language: cpp
 -
-
 stood
 standard


### PR DESCRIPTION
This is mostly the result of salvaging functionality from #1820 . I didn't want to break things up into a flurry of individual pull-request, but I did break up the individual features into individual commits.

This shouldn't change any existing functionality except of course he existing "type" command for C++, which becomes a lot more powerful. So I would hope that this can get merged with minimal fuss.

CC: @FireChickenProductivity 