### PR TITLE
Fix Lua's tryCatchStatement so it can be used to wrap arbitrary code

### DIFF
--- a/core/snippets/snippet_types.py
+++ b/core/snippets/snippet_types.py
@@ -47,7 +47,7 @@ class Snippet:
     def get_variable_strict(self, name: str):
         variable = self.get_variable(name)
         if variable is None:
-            raise ValueError(f"Snippet '{self.name}' has no variable '{name}'")
+            raise ValueError(f"No variable '{name}' in {self}")
         return variable
 
 

--- a/core/snippets/snippets/lua.snippet
+++ b/core/snippets/snippets/lua.snippet
@@ -4,6 +4,7 @@ language: lua
 name: forInIPairs
 phrase: for eye pairs
 insertionScope: statement
+
 $1.insertionFormatter: SNAKE_CASE
 -
 for _, $1 in ipairs($2) do
@@ -18,11 +19,4 @@ insertionScope: statement
 for ${1:k}, ${2:v} in pairs($3) do
     $0
 end
----
-
-name: tryCatchStatement
-phrase: try catch
-insertionScope: statement
--
-pcall($0)
 ---

--- a/core/snippets/snippets/tryCatchStatement.snippet
+++ b/core/snippets/snippets/tryCatchStatement.snippet
@@ -58,3 +58,12 @@ tryCatch({
     $3
 })
 ---
+
+language: lua
+-
+if pcall(function () $1 end) then
+    $2
+else
+    $0
+end
+---


### PR DESCRIPTION
Move it into tryCatchStatement.snippet with other implementations.

Uses the example from https://www.lua.org/pil/8.4.html.

Otherwise, try wrap in VSCode breaks due to the snippet not having $1.

Also add better information about *which* snippet is breaking wrapping, as it took me a while to realize that another language implementation was causing the problem.y