### PR TITLE
Add shorter form for semicolon

### DIFF
--- a/core/keys/symbols.py
+++ b/core/keys/symbols.py
@@ -57,7 +57,7 @@ symbols = [
     Symbol("`", ["back tick"], ["grave"]),
     Symbol(",", ["comma", "coma"]),
     Symbol(".", ["period", "full stop"], ["dot", "point"]),
-    Symbol(";", ["semicolon"]),
+    Symbol(";", ["semicolon"], ["semi"]),
     Symbol(":", ["colon"]),
     Symbol("?", ["question mark"], ["question"]),
     Symbol("!", ["exclamation mark", "exclamation point"], ["bang"]),


### PR DESCRIPTION
Given how common semicolons are in programming, I believe we should have a shorter standard form in command mode. Note that the old spoken form is for dictation mode and command mode but the new spoken form is only added to command mode.