### PR TITLE
Use shorter spoken form for bitwise operators

### DIFF
--- a/lang/tags/operators.talon
+++ b/lang/tags/operators.talon
@@ -2,7 +2,7 @@
 # so changing those commands will make the "help operators" command display the wrong prefixes
 op {user.code_operators_array}: user.code_operator(code_operators_array)
 op {user.code_operators_assignment}: user.code_operator(code_operators_assignment)
-op {user.code_operators_bitwise}: user.code_operator(code_operators_bitwise)
+(bit|bitwise) {user.code_operators_bitwise}: user.code_operator(code_operators_bitwise)
 op {user.code_operators_lambda}: user.code_operator(code_operators_lambda)
 op {user.code_operators_pointer}: user.code_operator(code_operators_pointer)
 op {user.code_operators_math}: user.code_operator(code_operators_math)

--- a/lang/tags/operators_assignment.talon-list
+++ b/lang/tags/operators_assignment.talon-list
@@ -13,10 +13,3 @@ times equals: ASSIGNMENT_MULTIPLICATION
 divide equals: ASSIGNMENT_DIVISION
 mod equals: ASSIGNMENT_MODULO
 increment: ASSIGNMENT_INCREMENT
-
-# Bitwise operators
-bitwise and equals: ASSIGNMENT_BITWISE_AND
-bitwise or equals: ASSIGNMENT_BITWISE_OR
-bitwise exclusive or equals: ASSIGNMENT_BITWISE_EXCLUSIVE_OR
-left shift equals: ASSIGNMENT_BITWISE_LEFT_SHIFT
-right shift equals: ASSIGNMENT_BITWISE_RIGHT_SHIFT

--- a/lang/tags/operators_bitwise.talon-list
+++ b/lang/tags/operators_bitwise.talon-list
@@ -2,10 +2,17 @@ list: user.code_operators_bitwise
 tag: user.code_operators_bitwise
 -
 
-bitwise and: BITWISE_AND
-bitwise or: BITWISE_OR
-bitwise not: BITWISE_NOT
+and: BITWISE_AND
+or: BITWISE_OR
+not: BITWISE_NOT
 
-bitwise ex or: BITWISE_EXCLUSIVE_OR
-bitwise left shift: BITWISE_LEFT_SHIFT
-bitwise right shift: BITWISE_RIGHT_SHIFT
+ex or: BITWISE_EXCLUSIVE_OR
+left shift: BITWISE_LEFT_SHIFT
+right shift: BITWISE_RIGHT_SHIFT
+
+# Assignment operators
+and equals: ASSIGNMENT_BITWISE_AND
+or equals: ASSIGNMENT_BITWISE_OR
+exclusive or equals: ASSIGNMENT_BITWISE_EXCLUSIVE_OR
+left shift equals: ASSIGNMENT_BITWISE_LEFT_SHIFT
+right shift equals: ASSIGNMENT_BITWISE_RIGHT_SHIFT


### PR DESCRIPTION
Use `(bit|bitwise)` instead of `op bitwise` as the prefix for bitwise operators. 

I am waiting on advice for how to handle deprecation/notifying users about this change before updating breaking changes.