### PR TITLE
Add captures for fractional decimal numbers

### DIFF
--- a/core/numbers/decimal_separator.talon-list
+++ b/core/numbers/decimal_separator.talon-list
@@ -1,0 +1,4 @@
+list: user.decimal_separator
+-
+point: .
+comma: ,

--- a/core/numbers/numbers.py
+++ b/core/numbers/numbers.py
@@ -219,7 +219,10 @@ number_word_leading = f"({'|'.join(leading_words)})"
 
 
 mod.list("number_small", "List of small (0-99) numbers")
-mod.list("decimal_separator", "A decimal separator separating the fractional from the integer part")
+mod.list(
+    "decimal_separator",
+    "A decimal separator separating the fractional from the integer part",
+)
 mod.tag("unprefixed_numbers", desc="Dont require prefix when saying a number")
 ctx.lists["user.number_small"] = get_spoken_form_under_one_hundred(
     0,
@@ -338,7 +341,7 @@ def decimal_string(m) -> str:
     may_omit_int_part_0 = has_decimal_places and m.decimal_separator == "."
 
     string = getattr(m, "number_string", "" if may_omit_int_part_0 else "0")
-    
+
     if has_decimal_places:
         string += m.decimal_separator
         string += m.digit_string
@@ -349,7 +352,7 @@ def decimal_string(m) -> str:
 @mod.capture(rule="<user.decimal_string>")
 def normalized_decimal_string(m) -> str:
     """`user.decimal_string`, normalized in the following manner:
-    
+
     - Integer part is always present
     - Decimal separator, if present, is always `.`
     """

--- a/core/numbers/numbers.py
+++ b/core/numbers/numbers.py
@@ -247,51 +247,55 @@ def handle_negation_capture(m):
 # TODO: allow things like "double eight" for 88
 @ctx.capture("digit_string", rule=f"({alt_digits} | {alt_teens} | {alt_tens})+")
 def digit_string(m) -> str:
+    """A sequence of digits, always allowing for bare and initial "oh"."""
     return parse_number(list(m))
 
 
 @ctx.capture("digits", rule="<digit_string>")
 def digits(m) -> int:
-    """Parses a phrase representing a digit sequence, returning it as an integer."""
+    """`digit_string`, converted to `int`."""
     return int(m.digit_string)
 
 
 @mod.capture(rule=f"{number_word_leading} ([and] {number_word})*")
 def number_string(m) -> str:
-    """Parses a number phrase, returning that number as a string."""
+    """An unsigned integer."""
     return parse_number(list(m))
 
 
 @ctx.capture("number", rule="<user.number_string>")
 def number(m) -> int:
-    """Parses a number phrase, returning it as an integer."""
+    """`user.number_string`, converted to `int`."""
     return int(m.number_string)
 
 
 @mod.capture(rule="[negative | minus] <user.number_string>")
 def number_signed_string(m) -> str:
-    """Parses a (possibly negative) number phrase, returning that number as a string."""
+    """Possibly negated variant of `user.number_string`."""
     return handle_negation_capture(m)
 
 
 @ctx.capture("number_signed", rule="<user.number_signed_string>")
 def number_signed(m) -> int:
-    """Parses a (possibly negative) number phrase, returning that number as a integer."""
+    """Possibly negated variant of `number`."""
     return int(m.number_signed_string)
 
 
 @mod.capture(rule="<user.number_string> ((dot | point) <user.number_string>)+")
 def number_prose_with_dot(m) -> str:
+    """Any number of `user.number_string` captures with dots in between."""
     return ".".join(m.number_string_list)
 
 
 @mod.capture(rule="<user.number_string> (comma <user.number_string>)+")
 def number_prose_with_comma(m) -> str:
+    """Any number of `user.number_string` captures with commas in between."""
     return ",".join(m.number_string_list)
 
 
 @mod.capture(rule="<user.number_string> (colon <user.number_string>)+")
 def number_prose_with_colon(m) -> str:
+    """Any number of `user.number_string` captures with colons in between."""
     return ":".join(m.number_string_list)
 
 
@@ -309,12 +313,13 @@ def number_prose_prefixed(m) -> str:
 
 @ctx.capture("number_small", rule="{user.number_small}")
 def number_small(m) -> int:
+    """An integer in the range from 0 to 99."""
     return int(m.number_small)
 
 
 @mod.capture(rule="[negative | minus] <number_small>")
 def number_signed_small(m) -> int:
-    """Parses an integer between -99 and 99."""
+    """Possibly negated variant of `number_small`."""
     return cast(int, handle_negation_capture(m))
 
 

--- a/core/numbers/numbers.py
+++ b/core/numbers/numbers.py
@@ -175,12 +175,14 @@ def split_list(value, l: list) -> Iterator:
 #     for scale in scales:
 #         old = l
 #         l = parse_scale(scale, l)
-#         if scale in old: print("  parse -->", l)
-#         else: assert old == l, "parse_scale should do nothing if the scale does not occur in the list"
+#         if scale in old:
+#             print("  parse -->", l)
+#         else:
+#             assert old == l, "parse_scale should do nothing if the scale does not occur in the list"
 #     result = "".join(str(n) for n in l)
 #     assert result == parse_number(string.split())
 #     assert str(expected) == result, f"parsing {string!r}, expected {expected}, got {result}"
-
+#
 # test_number(105000, "one hundred and five thousand")
 # test_number(1000000, "one thousand thousand")
 # test_number(1501000, "one million five hundred one thousand")
@@ -196,6 +198,7 @@ def split_list(value, l: list) -> Iterator:
 # test_number(1010, "one thousand ten")
 # test_number(123456, "one hundred and twenty three thousand and four hundred and fifty six")
 # test_number(123456, "one twenty three thousand four fifty six")
+# test_number("0019", "oh zero one nine") # fractional part of decimal number, or bare digit sequence
 
 # ## failing (and somewhat debatable) tests from old numbers.py
 # #test_number(10000011, "one million one one")

--- a/core/numbers/numbers.py
+++ b/core/numbers/numbers.py
@@ -303,7 +303,7 @@ def number_prose_with_colon(m) -> str:
 
 
 @mod.capture(
-    rule="<user.number_signed_string> | <user.number_prose_with_dot> | <user.number_prose_with_comma> | <user.number_prose_with_colon>"
+    rule="<user.signed_decimal_string> | <user.number_prose_with_dot> | <user.number_prose_with_comma> | <user.number_prose_with_colon>"
 )
 def number_prose_unprefixed(m) -> str:
     return m[0]

--- a/core/text/text_and_dictation.py
+++ b/core/text/text_and_dictation.py
@@ -65,13 +65,10 @@ def prose_modifier(m) -> Callable:
 
 
 @mod.capture(
-    rule="<user.number_string> [(dot | point) <digit_string>] percent [sign|sine]"
+    rule="<user.normalized_signed_decimal_string> percent [sign|sine]"
 )
 def prose_percent(m) -> str:
-    s = m.number_string
-    if hasattr(m, "digit_string"):
-        s += "." + m.digit_string
-    return s + "%"
+    return m.normalized_signed_decimal_string + "%"
 
 
 @mod.capture(

--- a/core/text/text_and_dictation.py
+++ b/core/text/text_and_dictation.py
@@ -64,9 +64,7 @@ def prose_modifier(m) -> Callable:
     return getattr(DictationFormat, m.prose_modifiers)
 
 
-@mod.capture(
-    rule="<user.normalized_signed_decimal_string> percent [sign|sine]"
-)
+@mod.capture(rule="<user.normalized_signed_decimal_string> percent [sign|sine]")
 def prose_percent(m) -> str:
     return m.normalized_signed_decimal_string + "%"
 

--- a/lang/css/css.talon
+++ b/lang/css/css.talon
@@ -25,9 +25,8 @@ rule <user.text>:
     name = user.formatted_text(text, "DASH_SEPARATED")
     insert("{name}: ")
 
-value <user.number_string> [{user.css_unit}]: "{number_string}{css_unit or ''}"
-value <user.number_string> point <digit_string> [{user.css_unit}]:
-    "{number_string}.{digit_string}{css_unit or ''}"
+value <user.normalized_signed_decimal_string> [{user.css_unit}]:
+    "{normalized_signed_decimal_string}{css_unit or ''}"
 
 (value | state) {user.css_global_value}: "{css_global_value}"
 value <user.text>: user.insert_formatted(text, "DASH_SEPARATED")


### PR DESCRIPTION
Benefits:

- I implemented basic mouse move commands that move the mouse cursor the said amount of centimeters (changeable to inches and other units), which I plan to contribute in the future. Centimeter values like "point five" or "two point five" are a regular occurrence.
- Rango's commands "upper" and "downer" currently only accept integers to scroll whole pages. The only fractional amount is used when omitting the number (0.66 pages). It's very easy to update Rango to simply use a float capture instead to allow for *any* fractional amount like "point five" or "one point five", or even "point one" or "point oh one" (like when you just scrolled, but the mouse cursor needs to get out of the way ever so slightly).
- EDIT: Input float literals into code editors, calculator apps, etc.