### PR TITLE
Change PHP's insertionFormatter to PRIVATE_CAMEL_CASE for function declaration snippet

### DIFF
--- a/core/snippets/snippets/functionDeclaration.snippet
+++ b/core/snippets/snippets/functionDeclaration.snippet
@@ -59,7 +59,7 @@ endfunction
 
 language: php
 
-$1.insertionFormatter: SNAKE_CASE
+$1.insertionFormatter: PRIVATE_CAMEL_CASE
 -
 function $1($2) {
     $0


### PR DESCRIPTION
This addresses issue #2253:

> I came across this inconsistency between https://github.com/talonhub/community/blob/main/lang/php/php.talon#L20 (PRIVATE_CAMEL_CASE) and https://github.com/talonhub/community/blob/main/core/snippets/snippets/functionDeclaration.snippet#L62 (SNAKE_CASE) and would like to submit a change that will use PRIVATE_CAMEL_CASE for the function declaration snippet.