### PR TITLE
Add delay before inserting tmux commands

### DIFF
--- a/apps/tmux/tmux.py
+++ b/apps/tmux/tmux.py
@@ -29,6 +29,7 @@ class TmuxActions:
     def tmux_enter_command(command: str = ""):
         """Enter tmux command mode and optionally insert a command without executing it."""
         actions.user.tmux_keybind(":")
+        actions.sleep("20ms")
         actions.insert(command)
 
     def tmux_execute_command(command: str):


### PR DESCRIPTION
On macOS, using Apple Terminal, commands that enter tmux command mode could occasionally fail because `actions.insert()` appeared to begin typing before tmux command mode was ready to receive input. I observed this while using the `split last` voice command. Occasionally, an `s` would be inserted into the shell instead of executing the tmux command.

Adding a short delay before `actions.insert(command)` resolved the issue in my testing on the environment below:

- macOS Tahoe 26.5
- Apple Terminal
- tmux 3.7b
- Talon 0.4.0

I don't know whether this is specific to this environment, but I was able to reproduce it consistently before the change and have not observed it since.