### PR TITLE
Enable tmux commands on macOS

### DIFF
--- a/apps/tmux/tmux_commands.talon
+++ b/apps/tmux/tmux_commands.talon
@@ -1,4 +1,3 @@
-os: linux
 tag: user.tmux
 -
 


### PR DESCRIPTION
## Summary

Enable the tmux command set on macOS by removing the Linux-only restriction and renaming the file to reflect that the commands are not platform-specific.

## Details

The commands in this file only send tmux's standard key bindings (for example `ctrl-b` followed by `c`, `n`, `p`, `%`, or `"`). I verified that they work on macOS, and they do not appear to rely on any Linux-specific functionality. Because of that, there is no reason for the commands to be restricted to Linux.

Since the file is no longer Linux-specific, it has been renamed from `tmux_linux.talon` to `tmux_commands.talon`.

## Testing

- Tested on macOS using tmux in Terminal.
- Not tested on Linux or Windows.