### PR TITLE
Add returns global class command to common language features

### DIFF
--- a/lang/tags/functions.talon
+++ b/lang/tags/functions.talon
@@ -22,6 +22,9 @@ tag: user.code_functions
 # for annotating function parameters
 is type <user.code_type>: user.code_insert_type_annotation(code_type)
 returns [type] <user.code_type>: user.code_insert_return_type(code_type)
+returns global class <user.text>:
+    formatted = user.formatted_text(text, "PUBLIC_CAMEL_CASE")
+    insert(": \\{formatted}")
 
 # for generic reference of types
 type <user.code_type>: insert(code_type)


### PR DESCRIPTION
**Edit: I'm closing my own PR because I can't find any evidence that coding languages other than C# have a prefix which can declare that a class reference in a type definition must resolve to the global namespace instead of the current namespace. I've resubmitted this for PHP in PR #2273.**

This pull request is related to issue #2266 and PR #2271.

It implements the "returns global class <user.text>" command in ./lang/tags/functions.talon.

Languages other than PHP may not need this command, and if that is the case I am fine with it being closed.

Since ./core/snippets/snippets/classDeclaration.snippet uses PUBLIC_CAMEL_CASE as the only insertion formatter, I will assume it is fine to use for this new command.

PHP uses [namespaces](https://www.php.net/manual/en/language.namespaces.definition.php) for class, interface, function, and constant definitions. Namespaces use the `\` character to declare subnamespaces, and a global namespace reference can be made by prefixing it with `\`. When a namespace is declared, namespace resolution first checks whether proceeding classes and functions are registered in that namespace. Prefixing them with "\" explicitly declares they use the global space. Simple example:

```php
<?php
namespace App;
function currentDate(): \DateTime {
    return new \DateTime();
}
```