### PR TITLE
Add returns global class command for PHP

### DIFF
--- a/lang/php/php.talon
+++ b/lang/php/php.talon
@@ -25,6 +25,9 @@ settings():
 
 state try: user.insert_snippet_by_name("tryStatement")
 state catch: user.insert_snippet_by_name("catchStatement")
+returns global class <user.text>:
+    formatted = user.formatted_text(text, "PUBLIC_CAMEL_CASE")
+    user.code_insert_return_type("\\" + formatted)
 
 var <phrase> [over]:
     insert("$")


### PR DESCRIPTION
This pull request is related to issue #2266, PR #2271, and PR #2272.

It implements the "returns global class <user.text>" command in ./lang/php/php.talon.

PHP uses [namespaces](https://www.php.net/manual/en/language.namespaces.definition.php) for class, interface, function, and constant definitions. Namespaces use the `\` character to declare subnamespaces, and a global namespace reference can be made by prefixing it with `\`. When a namespace is declared, namespace resolution first checks whether proceeding classes and functions are registered in that namespace. Prefixing them with "\" explicitly declares they use the global space. Simple example:

```php
<?php
namespace App;
function currentDate(): \DateTime {
    return new \DateTime();
}
```

I believe PHP is almost unique in this behavior, which is why I am submitting this PR to add this command to it instead of the common language features. I couldn't find any evidence that coding languages other than C# have a prefix which can declare that a class reference in a type definition must resolve to the global namespace instead of the current namespace.