### PR TITLE
Tmux fixes and cleanup

### DIFF
--- a/apps/tmux/tmux.py
+++ b/apps/tmux/tmux.py
@@ -17,13 +17,9 @@ mod.setting(
 
 @mod.action_class
 class TmuxActions:
-    def tmux_prefix():
-        """press control and the configured tmux prefix key"""
-        actions.key(settings.get("user.tmux_prefix_key"))
-
     def tmux_keybind(key: str):
         """press tmux prefix followed by a key bind"""
-        actions.user.tmux_prefix()
+        actions.key(settings.get("user.tmux_prefix_key"))
         actions.key(key)
 
     def tmux_enter_command(command: str = ""):

--- a/apps/tmux/tmux.py
+++ b/apps/tmux/tmux.py
@@ -57,6 +57,11 @@ class AppActions:
     def tab_previous():
         actions.user.tmux_execute_command("select-window -p")
 
+    def tab_close():
+        actions.user.tmux_execute_command_with_confirmation(
+            "kill-window", "kill-window #W?"
+        )
+
 
 @ctx.action_class("user")
 class UserActions:
@@ -65,11 +70,6 @@ class UserActions:
             actions.user.tmux_keybind(f"{number}")
         else:
             actions.user.tmux_execute_command(f"select-window -t {number}")
-
-    def tab_close_wrapper():
-        actions.user.tmux_execute_command_with_confirmation(
-            "kill-window", "kill-window #W?"
-        )
 
     def split_window_right():
         actions.user.split_window_horizontally()

--- a/apps/tmux/tmux_commands.talon
+++ b/apps/tmux/tmux_commands.talon
@@ -3,23 +3,26 @@ tag: user.tmux
 
 mux: "tmux "
 
-#session management
+# Session management
 mux new session: insert("tmux new ")
 mux sessions: user.tmux_keybind("s")
 mux name session: user.tmux_keybind("$")
 mux kill session: insert("tmux kill-session -t ")
-#window management
+
+# Window management
 mux new window: user.tmux_keybind("c")
 mux window <number>: user.tmux_keybind("{number}")
 mux previous window: user.tmux_keybind("p")
 mux next window: user.tmux_keybind("n")
 mux rename window: user.tmux_keybind(",")
 mux close window: user.tmux_keybind("&")
-#pane management
+
+# Pane management
 mux split horizontal: user.tmux_keybind("%")
 mux split vertical: user.tmux_keybind("\"")
 mux next pane: user.tmux_keybind("o")
 mux move <user.arrow_key>: user.tmux_keybind(arrow_key)
 mux close pane: user.tmux_keybind("x")
-#Say a number right after this command, to switch to pane
+
+# Say a number right after this command, to switch to pane
 mux pane numbers: user.tmux_keybind("q")

--- a/apps/tmux/tmux_commands.talon
+++ b/apps/tmux/tmux_commands.talon
@@ -5,49 +5,21 @@ mux: "tmux "
 
 #session management
 mux new session: insert("tmux new ")
-mux sessions:
-    key(ctrl-b)
-    key(s)
-mux name session:
-    key(ctrl-b)
-    key($)
+mux sessions: user.tmux_keybind("s")
+mux name session: user.tmux_keybind("$")
 mux kill session: insert("tmux kill-session -t ")
 #window management
-mux new window:
-    key(ctrl-b)
-    key(c)
-mux window <number>:
-    key(ctrl-b)
-    key('{number}')
-mux previous window:
-    key(ctrl-b)
-    key(p)
-mux next window:
-    key(ctrl-b)
-    key(n)
-mux rename window:
-    key(ctrl-b)
-    key(,)
-mux close window:
-    key(ctrl-b)
-    key(&)
+mux new window: user.tmux_keybind("c")
+mux window <number>: user.tmux_keybind("{number}")
+mux previous window: user.tmux_keybind("p")
+mux next window: user.tmux_keybind("n")
+mux rename window: user.tmux_keybind(",")
+mux close window: user.tmux_keybind("&")
 #pane management
-mux split horizontal:
-    key(ctrl-b)
-    key(%)
-mux split vertical:
-    key(ctrl-b)
-    key(")
-mux next pane:
-    key(ctrl-b)
-    key(o)
-mux move <user.arrow_key>:
-    key(ctrl-b)
-    key(arrow_key)
-mux close pane:
-    key(ctrl-b)
-    key(x)
+mux split horizontal: user.tmux_keybind("%")
+mux split vertical: user.tmux_keybind("\"")
+mux next pane: user.tmux_keybind("o")
+mux move <user.arrow_key>: user.tmux_keybind(arrow_key)
+mux close pane: user.tmux_keybind("x")
 #Say a number right after this command, to switch to pane
-mux pane numbers:
-    key(ctrl-b)
-    key(q)
+mux pane numbers: user.tmux_keybind("q")


### PR DESCRIPTION
Related to #2270

This PR addresses several aspects of the tmux integration that are independent of the pending architectural decision on whether the tmux .talon files should be merged or reorganized.

- Use user.tmux_keybind instead of hard-coded ctrl-b prefixes.
- Remove the unnecessary tmux_prefix action.
- Clean up tmux command comments.
- Have tmux use app.tab_close directly rather than using tab_close_wrapper unnecessarily.
- ~Fix the orientation of tmux split commands to match the conventions used in applications such as VS Code and Obsidian.~
