### PR TITLE
Fix help search ignoring help_max_command_lines_per_page setting 

### DIFF
--- a/core/help/help.py
+++ b/core/help/help.py
@@ -386,22 +386,30 @@ def draw_search_commands(gui: imgui.GUI):
         key=lambda item: context_map[item[0]] not in cached_active_contexts,
     )
 
-    pages = get_pages(
-        [
-            sum(get_command_line_count(command) for command in commands) + 3
-            for _, commands in sorted_commands_grouped
-        ]
-    )
+    # flatten to individual commands so get_pages applies the limit per-command, not per-context group
+    flat_commands = []
+    item_line_counts = []
+    for context, commands in sorted_commands_grouped:
+        for i, command in enumerate(commands):
+            flat_commands.append((context, command))
+            # add header overhead (title + separator + spacer) once per context group
+            item_line_counts.append(get_command_line_count(command) + (3 if i == 0 else 0))
+    pages = get_pages(item_line_counts)
     total_page_count = max(pages, default=1)
 
     draw_commands_title(gui, title)
 
-    for (context, commands), page in zip(sorted_commands_grouped, pages, strict=True):
-        if page == selected_context_page:
+    current_context = None
+    for (context, command), page in zip(flat_commands, pages, strict=True):
+        if page != selected_context_page:
+            continue
+        if context != current_context:
+            if current_context is not None:
+                gui.spacer()
             gui.text(format_context_title(context))
             gui.line()
-            draw_commands(gui, commands)
-            gui.spacer()
+            current_context = context
+        draw_commands(gui, [command])
 
 
 def get_search_commands(phrase: str) -> dict[str, tuple[str, str]]:

--- a/core/help/help.py
+++ b/core/help/help.py
@@ -393,7 +393,9 @@ def draw_search_commands(gui: imgui.GUI):
         for i, command in enumerate(commands):
             flat_commands.append((context, command))
             # add header overhead (title + separator + spacer) once per context group
-            item_line_counts.append(get_command_line_count(command) + (3 if i == 0 else 0))
+            item_line_counts.append(
+                get_command_line_count(command) + (3 if i == 0 else 0)
+            )
     pages = get_pages(item_line_counts)
     total_page_count = max(pages, default=1)
 

--- a/core/help/help.py
+++ b/core/help/help.py
@@ -411,7 +411,7 @@ def draw_search_commands(gui: imgui.GUI):
             gui.text(format_context_title(context))
             gui.line()
             current_context = context
-        draw_commands(gui, [command])
+        draw_command(gui, command)
 
 
 def get_search_commands(phrase: str) -> dict[str, tuple[str, str]]:
@@ -442,15 +442,20 @@ def draw_commands_title(gui: imgui.GUI, title: str):
     gui.line()
 
 
+def draw_command(gui: imgui.GUI, command: tuple[str, str]):
+    key, val = command
+    val = val.split("\n")
+    if len(val) > 1:
+        gui.text(f"{key}:")
+        for line in val:
+            gui.text(f"    {line}")
+    else:
+        gui.text(f"{key}: {val[0]}")
+
+
 def draw_commands(gui: imgui.GUI, commands: Iterable[tuple[str, str]]):
-    for key, val in commands:
-        val = val.split("\n")
-        if len(val) > 1:
-            gui.text(f"{key}:")
-            for line in val:
-                gui.text(f"    {line}")
-        else:
-            gui.text(f"{key}: {val[0]}")
+    for command in commands:
+        draw_command(gui, command)
 
 
 def reset():

--- a/core/help/help.py
+++ b/core/help/help.py
@@ -393,9 +393,7 @@ def draw_search_commands(gui: imgui.GUI):
         for i, command in enumerate(commands):
             flat_commands.append((context, command))
             # add header overhead (title + separator + spacer) once per context group
-            item_line_counts.append(
-                get_command_line_count(command) + (3 if i == 0 else 0)
-            )
+            item_line_counts.append(get_command_line_count(command) + (3 if i == 0 else 0))
     pages = get_pages(item_line_counts)
     total_page_count = max(pages, default=1)
 


### PR DESCRIPTION
"help search \<phrase\>" results could overflow a single page when many matching commands came from one context file. The pagination code treated each context's entire result group as an indivisible unit, so groups larger than the page limit were placed on an oversized page unchanged.

Fix: flatten grouped search results into individual commands before paginating, matching the approach already used by the single-context help view. Context headers are accounted for by adding their 3-line overhead to each group's first command.