### PR TITLE
Fix alphanumeric word bug in formatters

### DIFF
--- a/core/formatters/formatters.py
+++ b/core/formatters/formatters.py
@@ -84,7 +84,7 @@ class CodeFormatter(Formatter):
             if word.isnumeric():
                 first = True
             # Word is symbol
-            elif not word.isalpha():
+            elif not word.isalnum():
                 groups.append(delimiter.join(group))
                 word = word.strip()
                 if word != ".":

--- a/test/test_formatters.py
+++ b/test/test_formatters.py
@@ -16,6 +16,25 @@ if hasattr(talon, "test_mode"):
 
         assert result == "hello_world"
 
+    def test_snake_case_alnum():
+        result = formatters.Actions.formatted_text("hello x11 world", "SNAKE_CASE")
+
+        assert result == "hello_x11_world"
+
+    def test_snake_case_dot():
+        result = formatters.Actions.formatted_text(
+            "hello world. hello world", "SNAKE_CASE"
+        )
+
+        assert result == "hello_world.hello_world"
+
+    def test_snake_case_comma():
+        result = formatters.Actions.formatted_text(
+            "hello world, hello world", "SNAKE_CASE"
+        )
+
+        assert result == "hello_world, hello_world"
+
     def test_no_spaces():
         result = formatters.Actions.formatted_text("hello world", "NO_SPACES")
 


### PR DESCRIPTION
Words like `x11` were treated incorrectly in formatters since we didn't check for alphanumeric words.