### PR TITLE
Add code_insert_type_annotation to php.py

### DIFF
--- a/lang/php/php.py
+++ b/lang/php/php.py
@@ -158,5 +158,8 @@ class UserActions:
         actions.user.paste(result)
         actions.edit.left()
 
+    def code_insert_type_annotation(type: str):
+        actions.insert(f"{type} ")
+
     def code_insert_return_type(type: str):
         actions.insert(f": {type}")


### PR DESCRIPTION
This pull request addresses issue #2282 by adding a `code_insert_type_annotation` method to lang/php/php.py. This allows commands like "is type <user.code_type>" to resolve properly.