### PR TITLE
Add global class type to remaining type commands for PHP

### DIFF
--- a/lang/php/php.py
+++ b/lang/php/php.py
@@ -158,5 +158,8 @@ class UserActions:
         actions.user.paste(result)
         actions.edit.left()
 
+    def code_insert_type_annotation(type: str):
+        actions.insert(f"{type} ")
+
     def code_insert_return_type(type: str):
         actions.insert(f": {type}")

--- a/lang/php/php.talon
+++ b/lang/php/php.talon
@@ -29,6 +29,12 @@ state catch: user.insert_snippet_by_name("catchStatement")
 returns global class <user.text>:
     formatted = user.formatted_text(text, "PUBLIC_CAMEL_CASE")
     user.code_insert_return_type("\\" + formatted)
+is global class <user.text>:
+    formatted = user.formatted_text(text, "PUBLIC_CAMEL_CASE")
+    user.code_insert_type_annotation("\\" + formatted)
+global class <user.text>:
+    formatted = user.formatted_text(text, "PUBLIC_CAMEL_CASE")
+    user.code_insert_type_annotation("\\" + formatted)
 
 var <phrase> [over]:
     insert("$")


### PR DESCRIPTION
This pull request addresses issue #2281 by adding "is global class" and "global class" commands to lang/php/php.talon.

It may be redundant to have both commands, but they are meant to be analagous to "is type <user.code_type>" and "type <user.code_type>" found in lang/tags/functions.talon.