### PR TITLE
Fix tmux split orientation commands

### DIFF
--- a/BREAKING_CHANGES.txt
+++ b/BREAKING_CHANGES.txt
@@ -7,7 +7,7 @@ and when the change was applied given the delay between changes being
 submitted and the time they were reviewed and merged.
 
 ---
-* 2026-08-10 Change tmux split commands to match the orientation conventions we use for other applications such as VS Code and Obsidian.
+* 2026-08-10 Change tmux split commands to match the orientation conventions we use for other applications such as VS Code and Obsidian. (PR #2290)
 * 2026-07-25 Remove unused code for `presentation mode`. Use the `user.deep_sleep` tag instead.
 * 2026-05-17 Deprecate `state local`, `state end`, etc. for Lua in favour of using `put` via the list/capture/tag `user.code_keyword`.
 * 2025-12-22 the `user.mouse_wake` action now restores the eye tracking state to what it was before the last use of the `user.mouse_sleep` action instead of always enabling zoom mouse.

--- a/BREAKING_CHANGES.txt
+++ b/BREAKING_CHANGES.txt
@@ -7,6 +7,7 @@ and when the change was applied given the delay between changes being
 submitted and the time they were reviewed and merged.
 
 ---
+* 2026-08-10 Change tmux split commands to match the orientation conventions we use for other applications such as VS Code and Obsidian.
 * 2026-07-25 Remove unused code for `presentation mode`. Use the `user.deep_sleep` tag instead.
 * 2026-05-17 Deprecate `state local`, `state end`, etc. for Lua in favour of using `put` via the list/capture/tag `user.code_keyword`.
 * 2025-12-22 the `user.mouse_wake` action now restores the eye tracking state to what it was before the last use of the `user.mouse_sleep` action instead of always enabling zoom mouse.

--- a/apps/tmux/tmux.py
+++ b/apps/tmux/tmux.py
@@ -71,28 +71,31 @@ class UserActions:
         else:
             actions.user.tmux_execute_command(f"select-window -t {number}")
 
-    def split_window_right():
+    def split_window_up():
         actions.user.split_window_horizontally()
-        actions.user.tmux_execute_command("swap-pane -U -s #P")
-
-    def split_window_left():
-        actions.user.split_window_horizontally()
+        actions.user.tmux_execute_command("swap-pane -U")
 
     def split_window_down():
-        actions.user.split_window_vertically()
-        actions.user.tmux_execute_command("swap-pane -U -s #P")
+        actions.user.split_window_horizontally()
 
-    def split_window_up():
+    def split_window_left():
+        actions.user.split_window_vertically()
+        actions.user.tmux_execute_command("swap-pane -U")
+
+    def split_window_right():
         actions.user.split_window_vertically()
 
     def split_flip():
         actions.user.tmux_execute_command("next-layout")
 
+    # Tmux uses -h to create a left/right split. Applications such as VSCode and
+    # Obsidian call this a vertical split. By passing the -h flag, we keep the
+    # voice commands consistent with those used in those other applications.
     def split_window_vertically():
-        actions.user.tmux_execute_command("split-pane")
+        actions.user.tmux_execute_command("split-pane -h")
 
     def split_window_horizontally():
-        actions.user.tmux_execute_command("split-pane -h")
+        actions.user.tmux_execute_command("split-pane")
 
     def split_maximize():
         # toggle the maximization because zooming when already zoomed is pointless

--- a/apps/tmux/tmux_commands.talon
+++ b/apps/tmux/tmux_commands.talon
@@ -18,8 +18,8 @@ mux rename window: user.tmux_keybind(",")
 mux close window: user.tmux_keybind("&")
 
 # Pane management
-mux split horizontal: user.tmux_keybind("%")
-mux split vertical: user.tmux_keybind("\"")
+mux split horizontal: user.tmux_keybind("\"")
+mux split vertical: user.tmux_keybind("%")
 mux next pane: user.tmux_keybind("o")
 mux move <user.arrow_key>: user.tmux_keybind(arrow_key)
 mux close pane: user.tmux_keybind("x")


### PR DESCRIPTION
Tmux uses the -h flag for a left/right split, which applications such as VS Code and Obsidian call a vertical split. That meant issuing the voice commands "split horizontal" and "split vertical" would create the opposite of what a user coming from those other apps would expect. This commit aligns the tmux split voice commands with the orientation conventions used by these other applications: "split horizontal" will create a horizontal split (one pane on top of the other) and "split vertical" will create a vertical split (one pane to the left of the other).