### PR TITLE
Escape dollar signs in php loop snippets

### DIFF
--- a/core/snippets/snippets/forLoopReverseStatement.snippet
+++ b/core/snippets/snippets/forLoopReverseStatement.snippet
@@ -21,7 +21,7 @@ for i in reversed(range($1)):
 
 language: php
 -
-for ($i = $1; $i >= 0; $i--) {
+for (\$i = $1; \$i >= 0; \$i--) {
     $0
 }
 ---

--- a/core/snippets/snippets/forRangeStatement.snippet
+++ b/core/snippets/snippets/forRangeStatement.snippet
@@ -70,7 +70,7 @@ for i in 0..$1 {
 
 language: php
 -
-for ($i = 0; $i < $1; ++$i) {
+for (\$i = 0; \$i < $1; ++\$i) {
     $0
 }
 ---


### PR DESCRIPTION
This pull request addresses issue #2294 caused by a previous PR I created that was merged. It escapes the PHP variable `$i` in two snippet files: forRangeStatement.snippet and forLoopReverseStatement.snippet.