### PR TITLE
+Remove methods from Python function vocabulary

### DIFF
--- a/BREAKING_CHANGES.txt
+++ b/BREAKING_CHANGES.txt
@@ -7,6 +7,7 @@ and when the change was applied given the delay between changes being
 submitted and the time they were reviewed and merged.
 
 ---
+* 2026-08-23 Remove `split` and `update` from the Python function vocabulary. These are methods, not built-in Python functions, and should now be invoked with the method voice command instead (e.g. "dot split" instead of "funk split").
 * 2026-08-10 Change tmux split commands to match the orientation conventions we use for other applications such as VS Code and Obsidian. (PR #2290)
 * 2026-07-25 Remove unused code for `presentation mode`. Use the `user.deep_sleep` tag instead.
 * 2026-05-17 Deprecate `state local`, `state end`, etc. for Lua in favour of using `put` via the list/capture/tag `user.code_keyword`.

--- a/lang/python/code_common_function.talon-list
+++ b/lang/python/code_common_function.talon-list
@@ -23,11 +23,9 @@ range
 reversed
 round
 set
-split
 sorted
 string: "str"
 sum
 tuple
 type
-update
 zip


### PR DESCRIPTION
`split` and `update` are not Python built-in functions and thus shouldn't be in `code_common_function.talon-list`. They are methods invoked on objects, so calling them with the function voice commands does not make sense.

They should be called with the method voice commands already available through the Python method vocabulary in `code_common_method.talon-list`.

Example: `.split()` is now exclusively invoked through the method voice command "dot split" instead of by chaining two voice commands ("dot" + "funk split").