### PR TITLE
Remove deprecated actions command

### DIFF
--- a/apps/jetbrains/jetbrains.talon
+++ b/apps/jetbrains/jetbrains.talon
@@ -18,7 +18,6 @@ smart: user.idea("action SmartTypeCompletion")
 done | finish: user.idea("action EditorCompleteStatement")
 # Copying
 grab <number>: user.idea_grab(number)
-action [<user.text>]: user.deprecate_command("2024-09-02", "action", "please")
 # Refactoring
 refactor: user.idea("action Refactorings.QuickListPopupAction")
 refactor <user.text>:

--- a/plugin/dropdown/dropdown.talon
+++ b/plugin/dropdown/dropdown.talon
@@ -1,4 +1,0 @@
-# DEPRECATED
-drop down <number_small>: user.deprecate_command("2024-05-29", "drop down", "choose")
-drop down up <number_small>:
-    user.deprecate_command("2024-05-29", "drop down up", "choose up")


### PR DESCRIPTION
This was deprecated over a year ago and no longer does anything, so I think we should just remove it.