### PR TITLE
Remove action command

### DIFF
--- a/BREAKING_CHANGES.txt
+++ b/BREAKING_CHANGES.txt
@@ -7,6 +7,7 @@ and when the change was applied given the delay between changes being
 submitted and the time they were reviewed and merged.
 
 ---
+* 2026-08-23 Removed deprecated Jetbrains command `action` in favour of the `please` command. 
 * 2026-08-10 Change tmux split commands to match the orientation conventions we use for other applications such as VS Code and Obsidian. (PR #2290)
 * 2026-07-25 Remove unused code for `presentation mode`. Use the `user.deep_sleep` tag instead.
 * 2026-05-17 Deprecate `state local`, `state end`, etc. for Lua in favour of using `put` via the list/capture/tag `user.code_keyword`.

--- a/BREAKING_CHANGES.txt
+++ b/BREAKING_CHANGES.txt
@@ -7,7 +7,7 @@ and when the change was applied given the delay between changes being
 submitted and the time they were reviewed and merged.
 
 ---
-* 2026-08-23 Removed deprecated Jetbrains command `action` in favour of the `please` command. 
+* 2026-08-23 Removed deprecated Jetbrains command `action` in favour of the `please` command.
 * 2026-08-10 Change tmux split commands to match the orientation conventions we use for other applications such as VS Code and Obsidian. (PR #2290)
 * 2026-07-25 Remove unused code for `presentation mode`. Use the `user.deep_sleep` tag instead.
 * 2026-05-17 Deprecate `state local`, `state end`, etc. for Lua in favour of using `put` via the list/capture/tag `user.code_keyword`.

--- a/apps/jetbrains/jetbrains.talon
+++ b/apps/jetbrains/jetbrains.talon
@@ -18,7 +18,6 @@ smart: user.idea("action SmartTypeCompletion")
 done | finish: user.idea("action EditorCompleteStatement")
 # Copying
 grab <number>: user.idea_grab(number)
-action [<user.text>]: user.deprecate_command("2024-09-02", "action", "please")
 # Refactoring
 refactor: user.idea("action Refactorings.QuickListPopupAction")
 refactor <user.text>:


### PR DESCRIPTION
Given that the command no longer does anything and has been deprecated for a over year, I think we should just remove it.