### PR TITLE
Added mouse_click_with_hold tag

### DIFF
--- a/plugin/mouse/mouse.py
+++ b/plugin/mouse/mouse.py
@@ -172,4 +172,4 @@ class UserActions:
         )
 
         if should_click:
-            ctrl.mouse_click(button=0, hold=16000)
+            actions.mouse_click(0)

--- a/plugin/mouse/mouse.py
+++ b/plugin/mouse/mouse.py
@@ -172,4 +172,4 @@ class UserActions:
         )
 
         if should_click:
-            actions.mouse_click(0)
+            actions.mouse_click()

--- a/plugin/mouse/mouse_click_with_hold.py
+++ b/plugin/mouse/mouse_click_with_hold.py
@@ -1,4 +1,4 @@
-from talon import Context, Module, actions, ctrl
+from talon import Context, Module, actions, ctrl, settings
 
 mod = Module()
 
@@ -15,7 +15,7 @@ ctx = Context()
 @ctx.action_class("main")
 class MainActions:
     def mouse_click(button: int = 0):
-        hold_duration = actions.settings.get("user.mouse_click_hold")
+        hold_duration = settings.get("user.mouse_click_hold")
 
         if hold_duration < 1:
             actions.next(button)

--- a/plugin/mouse/mouse_click_with_hold.py
+++ b/plugin/mouse/mouse_click_with_hold.py
@@ -1,20 +1,23 @@
-from talon import Context, Module, ctrl
+from talon import Context, Module, actions, ctrl
 
 mod = Module()
 
-mod.tag(
-    "mouse_click_with_hold",
-    desc="Hold mouse buttons for 16 ms so clicks register reliably",
+mod.setting(
+    "mouse_click_hold",
+    type=int,
+    default=0,
+    desc="Duration to hold mouse clicks in milliseconds",
 )
 
 ctx = Context()
-ctx.matches = r"""
-tag: user.mouse_click_with_hold
-"""
 
 
 @ctx.action_class("main")
 class MainActions:
-    @staticmethod
     def mouse_click(button: int = 0):
-        ctrl.mouse_click(button=button, hold=16000)
+        hold_duration = actions.settings.get("user.mouse_click_hold")
+
+        if hold_duration < 1:
+            actions.next(button)
+        else:
+            ctrl.mouse_click(button=button, hold=hold_duration * 1000)

--- a/plugin/mouse/mouse_click_with_hold.py
+++ b/plugin/mouse/mouse_click_with_hold.py
@@ -3,13 +3,13 @@ from talon import Context, Module, ctrl
 mod = Module()
 
 mod.tag(
-    "mouse_long_click",
-    desc="Tag for enabling long click behavior",
+    "mouse_click_with_hold",
+    desc="Hold mouse buttons for 16 ms so clicks register reliably",
 )
 
 ctx = Context()
 ctx.matches = r"""
-tag: user.mouse_long_click
+tag: user.mouse_click_with_hold
 """
 
 

--- a/plugin/mouse/mouse_long_click.py
+++ b/plugin/mouse/mouse_long_click.py
@@ -1,0 +1,20 @@
+from talon import Context, Module, ctrl
+
+mod = Module()
+
+mod.tag(
+    "mouse_long_click",
+    desc="Tag for enabling long click behavior",
+)
+
+ctx = Context()
+ctx.matches = r"""
+tag: user.mouse_long_click
+"""
+
+
+@ctx.action_class("main")
+class MainActions:
+    @staticmethod
+    def mouse_click(button: int = 0):
+        ctrl.mouse_click(button=button, hold=16000)

--- a/settings.talon
+++ b/settings.talon
@@ -62,8 +62,9 @@ settings():
     user.mouse_wheel_horizontal_amount = 40
 
     # Set the duration to hold mouse clicks in milliseconds. 0 means no hold.
-    # In some full screen applications, particular games, mouse clicks may not be recognized unless held for a short duration.
-    # Recommended value for such cases is to try with 16 ms.
+    # In some full-screen applications, particularly games, mouse clicks may not
+	  # be recognized unless held for a short duration.  If this occurs, try
+    # starting with a setting of 16.
     user.mouse_click_hold = 0
 
     # If `true`, start mouse grid numbering on the bottom left (vs. top left)

--- a/settings.talon
+++ b/settings.talon
@@ -45,6 +45,9 @@ settings():
     # If `true`, use a hissing noise to scroll continuously
     user.mouse_enable_hiss_scroll = false
 
+    # If `true`, hold the mouse buttons down for 16 ms when clicking to increase reliability.
+    user.mouse_click_with_hold = false
+
     # How much time a hiss must last for to be considered a hiss rather than
     # part of speech, in ms
     user.hiss_scroll_debounce_time = 100

--- a/settings.talon
+++ b/settings.talon
@@ -63,7 +63,7 @@ settings():
 
     # Set the duration to hold mouse clicks in milliseconds. 0 means no hold.
     # In some full-screen applications, particularly games, mouse clicks may not
-	  # be recognized unless held for a short duration.  If this occurs, try
+    # be recognized unless held for a short duration.  If this occurs, try
     # starting with a setting of 16.
     user.mouse_click_hold = 0
 

--- a/settings.talon
+++ b/settings.talon
@@ -45,9 +45,6 @@ settings():
     # If `true`, use a hissing noise to scroll continuously
     user.mouse_enable_hiss_scroll = false
 
-    # If `true`, hold mouse buttons for 16 ms so clicks register reliably
-    user.mouse_click_with_hold = false
-
     # How much time a hiss must last for to be considered a hiss rather than
     # part of speech, in ms
     user.hiss_scroll_debounce_time = 100
@@ -139,3 +136,6 @@ settings():
 # Uncomment the below to enable the experimental window layout commands
 # defined in window_layout.talon
 # tag(): user.experimental_window_layout
+
+# Uncomment the below to hold mouse buttons for 16 ms so clicks register reliably
+# tag(): user.mouse_click_with_hold

--- a/settings.talon
+++ b/settings.talon
@@ -45,7 +45,7 @@ settings():
     # If `true`, use a hissing noise to scroll continuously
     user.mouse_enable_hiss_scroll = false
 
-    # If `true`, hold the mouse buttons down for 16 ms when clicking to increase reliability.
+    # If `true`, hold mouse buttons for 16 ms so clicks register reliably
     user.mouse_click_with_hold = false
 
     # How much time a hiss must last for to be considered a hiss rather than

--- a/settings.talon
+++ b/settings.talon
@@ -61,6 +61,11 @@ settings():
     # Set the amount to scroll left/right
     user.mouse_wheel_horizontal_amount = 40
 
+    # Set the duration to hold mouse clicks in milliseconds. 0 means no hold.
+    # In some full screen applications, particular games, mouse clicks may not be recognized unless held for a short duration.
+    # Recommended value for such cases is to try with 16 ms.
+    user.mouse_click_hold = 0
+
     # If `true`, start mouse grid numbering on the bottom left (vs. top left)
     user.grids_put_one_bottom_left = true
 
@@ -136,6 +141,3 @@ settings():
 # Uncomment the below to enable the experimental window layout commands
 # defined in window_layout.talon
 # tag(): user.experimental_window_layout
-
-# Uncomment the below to hold mouse buttons for 16 ms so clicks register reliably
-# tag(): user.mouse_click_with_hold


### PR DESCRIPTION
Added setting `user.mouse_click_hold`  to enable hold duration for `mouse_click` action. Useful for games and other full screen applications where the default mouse click doesn't register.