### PR TITLE
fix(edit): honor spoken count for character-level clear/select

### DIFF
--- a/core/edit/edit_command.py
+++ b/core/edit/edit_command.py
@@ -189,9 +189,14 @@ class Actions:
             # Custom callbacks take three parameters, compound callbacks do not.
             if signature(cb).parameters.get("count"):
                 cb(action, modifier.type, count)
-            else:
+                return
+            elif count == 1:
                 cb()
-            return
+                return
+            # Compound callbacks that don't accept a count have no way to
+            # honor a spoken count > 1 (e.g. "clear five right"), so fall
+            # through to the generic per-repeat modifier/action path below
+            # instead of silently discarding the count.
 
         actions.user.run_edit_modifier_callback(modifier)
         actions.user.run_edit_action_callback(action)

--- a/core/edit/edit_command.py
+++ b/core/edit/edit_command.py
@@ -190,7 +190,7 @@ class Actions:
             if signature(cb).parameters.get("count"):
                 cb(action, modifier.type, count)
                 return
-            elif count == 1:
+            if count == 1:
                 cb()
                 return
             # Compound callbacks that don't accept a count have no way to

--- a/core/edit/edit_command.py
+++ b/core/edit/edit_command.py
@@ -193,10 +193,6 @@ class Actions:
             if count == 1:
                 cb()
                 return
-            # Compound callbacks that don't accept a count have no way to
-            # honor a spoken count > 1 (e.g. "clear five right"), so fall
-            # through to the generic per-repeat modifier/action path below
-            # instead of silently discarding the count.
 
         actions.user.run_edit_modifier_callback(modifier)
         actions.user.run_edit_action_callback(action)

--- a/core/edit/edit_command_modifiers.py
+++ b/core/edit/edit_command_modifiers.py
@@ -11,11 +11,6 @@ mod.list(
     desc="Edit modifiers that are repeatable. Say a number before the modifier to repeat the action that many times.",
 )
 
-# Talon can fire repeated key events much faster than a human, which some
-# apps drop or coalesce (see the similar word/line selection delays in
-# edit_command.py). Without this, a repeatable modifier's count is
-# unreliable, e.g. "clear five right" nondeterministically acting on fewer
-# than 5 characters.
 mod.setting(
     "edit_command_repeat_delay",
     type=int,

--- a/core/edit/edit_command_modifiers.py
+++ b/core/edit/edit_command_modifiers.py
@@ -2,13 +2,25 @@ from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
 
-from talon import Module, actions
+from talon import Module, actions, settings
 
 mod = Module()
 mod.list("edit_modifier", desc="Modifiers for the edit command")
 mod.list(
     "edit_modifier_repeatable",
     desc="Edit modifiers that are repeatable. Say a number before the modifier to repeat the action that many times.",
+)
+
+# Talon can fire repeated key events much faster than a human, which some
+# apps drop or coalesce (see the similar word/line selection delays in
+# edit_command.py). Without this, a repeatable modifier's count is
+# unreliable, e.g. "clear five right" nondeterministically acting on fewer
+# than 5 characters.
+mod.setting(
+    "edit_command_repeat_delay",
+    type=int,
+    default=75,
+    desc="Sleep (ms) between repeated presses of a repeatable edit modifier",
 )
 
 
@@ -73,8 +85,10 @@ class Actions:
         """
         count = modifier.count
         modifier_callback = actions.user.get_edit_modifier_callback(modifier)
+        delay = f"{settings.get('user.edit_command_repeat_delay')}ms"
         for _ in range(1, count + 1):
             modifier_callback()
+            actions.sleep(delay)
 
     def get_edit_modifier_callback(modifier: EditModifier):
         """Convert an edit modifier created from a string into its associated EditModifierCallback"""

--- a/tags/terminal/readline_vi.py
+++ b/tags/terminal/readline_vi.py
@@ -55,6 +55,14 @@ def delete_word_right():
     normal_cmd("right d w i")
 
 
+def delete_chars_right(action, modifier_type, count):
+    normal_cmd(f"{' '.join(str(count))} x i")
+
+
+def delete_chars_left(action, modifier_type, count):
+    normal_cmd(f"{' '.join(str(count))} X i")
+
+
 simple_action_callbacks: dict[str, Callable] = {}
 
 custom_callbacks = {}
@@ -63,6 +71,8 @@ compound_actions = {
     ("delete", "word"): lambda: normal_cmd("d i w"),
     ("delete", "wordLeft"): lambda: actions.key("ctrl-w"),
     ("delete", "wordRight"): delete_word_right,
+    ("delete", "left"): delete_chars_left,
+    ("delete", "right"): delete_chars_right,
     ("cutToClipboard", "word"): lambda: normal_cmd("c i w "),
     ("cutToClipboard", "wordLeft"): lambda: normal_cmd("c b"),
     ("cutToClipboard", "wordRight"): lambda: normal_cmd("c w"),


### PR DESCRIPTION
## Overview

Fixes `clear`/`select` silently dropping a spoken count greater than 1 for character-level `left`/`right` modifiers.

<details>

- Modifiers like `left`/`right` were mapped straight to a built-in action with no `count` parameter, so any count > 1 (e.g. "clear five right") was silently dropped to 1.
- Falling through to the generic count-aware path exposed a second issue: rapid repeated key events with no delay between them were being dropped/coalesced in some apps, making the count nondeterministic even once it was no longer ignored.
- New setting `user.edit_command_repeat_delay` (default 75ms) controls the added delay, matching the existing word/line selection delay pattern.

</details>

## Related

- Originally introduced in #1641

## Changes

- **fixed** count handling for character modifiers
- **added** repeat delay setting

## Testing

1. In a text editor, place the cursor mid-line and say "clear right".
    - <sub>(Unchanged Behavior)</sub>\
      Exactly 1 character right of the cursor is deleted (unchanged fast-path behavior for count 1).
2. Say "clear five right".
    - <sub>(Fixed Behavior)</sub>\
      Exactly 5 characters right of the cursor are deleted, repeatably and deterministically.
3. Say "clear five left".
    - <sub>(Fixed Behavior)</sub>\
      Exactly 5 characters left of the cursor are deleted.
4. Say "clear five word right".
    - <sub>(Unchanged Behavior)</sub>\
      Still deletes 5 words (already worked before this fix).
