### PR TITLE
Permit multiple user snippet directories

### DIFF
--- a/core/snippets/snippets.py
+++ b/core/snippets/snippets.py
@@ -4,6 +4,7 @@ from typing import Union
 from talon import Context, Module, actions, app, fs, settings
 
 from ..modes.code_languages import code_languages
+from ..user_settings import parse_snippet_dirs
 from .snippet_types import (
     InsertionSnippet,
     Snippet,
@@ -25,7 +26,19 @@ mod.setting(
     "snippets_dir",
     type=str,
     default=None,
-    desc="Directory (relative to Talon user) containing additional snippets",
+    desc="""
+    Directory path(s) containing additional snippets. Can be relative to the Talon user folder or absolute.
+
+    Accepts a single path, or multiple paths separated by pipe (`|`) characters.
+    Spaces inside path names are supported directly and do not need to be escaped.
+    Whitespace around the `|` delimiter is automatically trimmed.
+
+    Examples:
+      - Single relative path: "my_snippets"
+      - Path containing spaces: "my custom snippets/python"
+      - Absolute path: "/Users/name/documents/snippets"
+      - Multiple paths: "my_snippets | /var/snippets | custom snippets/lang"
+    """,
 )
 
 # `_` represents the global context, ie snippets available regardless of language
@@ -46,18 +59,10 @@ for lang in code_languages:
     languages_state_map[lang.id] = SnippetLanguageState(ctx, SnippetLists())
 
 
-def get_setting_dir():
-    setting_dir = settings.get("user.snippets_dir")
-    if not setting_dir:
-        return None
-
-    dir = Path(setting_dir)
-
-    if not dir.is_absolute():
-        user_dir = Path(actions.path.talon_user())
-        dir = user_dir / dir
-
-    return dir.resolve()
+def get_setting_dirs() -> list[Path]:
+    setting_val = settings.get("user.snippets_dir")
+    user_dir = Path(actions.path.talon_user())
+    return parse_snippet_dirs(setting_val, user_dir)
 
 
 @mod.action_class
@@ -210,15 +215,15 @@ def update_contexts(language_to_lists: dict[str, SnippetLists]):
 
 
 def get_snippets_from_files() -> list[Snippet]:
-    setting_dir = get_setting_dir()
     result = []
 
     for file in SNIPPETS_DIR.glob("**/*.snippet"):
         result.extend(create_snippets_from_file(file))
 
-    if setting_dir:
-        for file in setting_dir.glob("**/*.snippet"):
-            result.extend(create_snippets_from_file(file))
+    for setting_dir in get_setting_dirs():
+        if setting_dir.exists():
+            for file in setting_dir.glob("**/*.snippet"):
+                result.extend(create_snippets_from_file(file))
 
     return result
 
@@ -226,8 +231,9 @@ def get_snippets_from_files() -> list[Snippet]:
 def on_ready():
     fs.watch(SNIPPETS_DIR, lambda _path, _flags: update_snippets())
 
-    if get_setting_dir():
-        fs.watch(get_setting_dir(), lambda _path, _flags: update_snippets())
+    for setting_dir in get_setting_dirs():
+        if setting_dir.exists():
+            fs.watch(setting_dir, lambda _path, _flags: update_snippets())
 
     update_snippets()
 

--- a/core/user_settings.py
+++ b/core/user_settings.py
@@ -195,3 +195,22 @@ def track_csv_rows(
 def warn_about_error(message: str):
     actions.app.notify(message)
     print(message)
+
+def parse_snippet_dirs(raw_setting: str | None, base_dir: Path | None = None) -> list[Path]:
+    """Parses a pipe-separated string of directories into resolved Path objects."""
+    if not raw_setting or not raw_setting.strip():
+        return []
+
+    dirs: list[Path] = []
+    for segment in raw_setting.split("|"):
+        segment = segment.strip()
+        if not segment:
+            continue
+
+        path = Path(segment)
+        if not path.is_absolute() and base_dir is not None:
+            path = base_dir / path
+
+        dirs.append(path.resolve())
+
+    return dirs

--- a/core/user_settings.py
+++ b/core/user_settings.py
@@ -196,7 +196,10 @@ def warn_about_error(message: str):
     actions.app.notify(message)
     print(message)
 
-def parse_snippet_dirs(raw_setting: str | None, base_dir: Path | None = None) -> list[Path]:
+
+def parse_snippet_dirs(
+    raw_setting: str | None, base_dir: Path | None = None
+) -> list[Path]:
     """Parses a pipe-separated string of directories into resolved Path objects."""
     if not raw_setting or not raw_setting.strip():
         return []

--- a/test/test_user_settings.py
+++ b/test/test_user_settings.py
@@ -1,5 +1,6 @@
-import talon
 from pathlib import Path
+
+import talon
 
 if hasattr(talon, "test_mode"):
     from core.user_settings import parse_snippet_dirs

--- a/test/test_user_settings.py
+++ b/test/test_user_settings.py
@@ -1,0 +1,33 @@
+import talon
+from pathlib import Path
+
+if hasattr(talon, "test_mode"):
+    from core.user_settings import parse_snippet_dirs
+
+    BASE_DIR = Path("/fake/user/dir")
+
+    def test_parse_snippet_dirs_empty():
+        assert parse_snippet_dirs(None, BASE_DIR) == []
+        assert parse_snippet_dirs("", BASE_DIR) == []
+        assert parse_snippet_dirs("   ", BASE_DIR) == []
+
+    def test_parse_snippet_dirs_single_relative():
+        expected = [(BASE_DIR / "snippets").resolve()]
+        assert parse_snippet_dirs("snippets", BASE_DIR) == expected
+
+    def test_parse_snippet_dirs_single_absolute():
+        expected = [Path("/opt/snippets").resolve()]
+        assert parse_snippet_dirs("/opt/snippets", BASE_DIR) == expected
+
+    def test_parse_snippet_dirs_with_spaces():
+        expected = [(BASE_DIR / "my custom snippets/python").resolve()]
+        assert parse_snippet_dirs("my custom snippets/python", BASE_DIR) == expected
+
+    def test_parse_snippet_dirs_multiple_paths():
+        raw = " my_snippets | /var/snippets | custom snippets/lang "
+        expected = [
+            (BASE_DIR / "my_snippets").resolve(),
+            Path("/var/snippets").resolve(),
+            (BASE_DIR / "custom snippets/lang").resolve(),
+        ]
+        assert parse_snippet_dirs(raw, BASE_DIR) == expected


### PR DESCRIPTION
This is useful for example if you have both a personal set of snippets, and a project/job/machine specific set